### PR TITLE
Replace the deprecated 'startActivityForResult'

### DIFF
--- a/bluetoothle/src/main/java/com/sample/android/bluetoothle/kotlin/MainActivity.kt
+++ b/bluetoothle/src/main/java/com/sample/android/bluetoothle/kotlin/MainActivity.kt
@@ -28,8 +28,19 @@ class MainActivity : AppCompatActivity() {
         // displays a dialog requesting user permission to enable Bluetooth.
         if (bluetoothAdapter == null || !bluetoothAdapter.isEnabled) {
             val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
-            startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT)
+            getResult.launch(enableBtIntent)            
         }
         // [END enable_bluetooth]
     }
+    
+    private val getResult =
+        registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) {
+            if (it.resultCode == Activity.RESULT_OK) {
+                // granted
+            } else {
+                // denied
+            }
+        }
 }


### PR DESCRIPTION
I was just stepping through the tutorial and saw that 'startActivityForResult' was deprecated, so I searched for the new way to launch an activity and pasted it here. 