### PR TITLE
Fixing Brush: Gradients and Shaders snippet duplication

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/BrushExampleSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/BrushExampleSnippets.kt
@@ -269,16 +269,6 @@ fun GraphicsImageBrush() {
         )
     )
 
-    // Use ImageShader Brush with TextStyle
-    Text(
-        text = "Hello Android!",
-        style = TextStyle(
-            brush = imageBrush,
-            fontWeight = FontWeight.ExtraBold,
-            fontSize = 36.sp
-        )
-    )
-
     // Use ImageShader Brush with DrawScope#drawCircle()
     Canvas(onDraw = {
         drawCircle(imageBrush)


### PR DESCRIPTION
As per https://developer.android.com/jetpack/compose/graphics/draw/brush#image-as-brush there is a duplication in the code snippet for usage of brush in Text.