### PR TITLE
Add missing @Preview annotation to an example of a @Preview-annotated Composable

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/tooling/AndroidStudioComposeSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/tooling/AndroidStudioComposeSnippets.kt
@@ -46,6 +46,7 @@ fun SimpleComposable() {
 // [END android_compose_tooling_simple_composable]
 
 // [START android_compose_tooling_simple_composable_preview]
+@Preview
 @Composable
 fun SimpleComposablePreview() {
     SimpleComposable()


### PR DESCRIPTION
The documentation section that shows the changed snippet expects it to contain a `@Preview` annotation, but it currently doesn't. This MR adds the missing annotation:

<img width="1096" alt="Screen Shot 2023-03-14 at 16 09 32" src="https://user-images.githubusercontent.com/21069/225046304-35f713a3-4350-49e0-8e89-6ccce0ab3974.png">
