### PR TITLE
Make custom column's children not restricted by column's height

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/CustomLayoutSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/CustomLayoutSnippets.kt
@@ -118,9 +118,10 @@ private object CustomLayoutsSnippet4 {
         ) { measurables, constraints ->
             // measure and position children given constraints logic here
             // [START_EXCLUDE]
+            val looseConstraints = constraints.copy(minHeight = 0)
             val placeables = measurables.map { measurable ->
                 // Measure each children
-                measurable.measure(constraints)
+                measurable.measure(looseConstraints)
             }
 
             // Set the size of the layout as big as it can


### PR DESCRIPTION
This fixes the layout and make the example fit the description:

> The child composables are constrained by the Layout constraints (without the minHeight constraints), and they're placed based on the yPosition of the previous composable.