### PR TITLE
updating glance and agp versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 #####
 [versions]
 accompanist = "0.30.1"
-androidGradlePlugin = "8.1.0"
+androidGradlePlugin = "8.1.1"
 androidx-activity-compose = "1.8.0-alpha06"
 androidx-appcompat = "1.6.1"
 androidx-benchmark = "1.1.1"
@@ -17,7 +17,7 @@ androidx-coordinator-layout = "1.2.0"
 androidx-corektx = "1.9.0"
 androidx-emoji2-views = "1.4.0-beta05"
 androidx-fragment-ktx = "1.6.1"
-androidx-glance-appwidget = "1.0.0-rc01"
+androidx-glance-appwidget = "1.0.0"
 androidx-lifecycle-compose = "2.6.1"
 androidx-lifecycle-runtime-compose = "2.6.1"
 androidx-navigation = "2.7.0"


### PR DESCRIPTION
This PR updates AGP to 8.1.1 and Glance to 1.0.0

Testing : 
 Simply build and run the compose samples.