### PR TITLE
Removing dispatcher from Bitmap writing

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -28,6 +28,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -45,8 +46,13 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
@@ -108,7 +114,7 @@ fun BitmapFromComposableSnippet() {
     // and shares it with the default share sheet.
     fun shareBitmapFromComposable() {
         if (writeStorageAccessState.allPermissionsGranted) {
-            coroutineScope.launch(Dispatchers.IO) {
+            coroutineScope.launch {
                 val bitmap = createBitmapFromPicture(picture)
                 val uri = bitmap.saveToDisk(context)
                 shareBitmap(context, uri)
@@ -169,6 +175,7 @@ fun BitmapFromComposableSnippet() {
 
         ) {
             ScreenContentToCapture()
+
         }
         // [END android_compose_draw_into_bitmap]
     }
@@ -176,6 +183,13 @@ fun BitmapFromComposableSnippet() {
 
 @Composable
 private fun ScreenContentToCapture() {
+    val time by produceState(0f) {
+        while (true) {
+            withInfiniteAnimationFrameMillis {
+                value = it / 1000f
+            }
+        }
+    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -202,14 +216,15 @@ private fun ScreenContentToCapture() {
             "Into the Ocean depths",
             fontSize = 18.sp
         )
+        Text(time.toString())
     }
 }
 
 private fun createBitmapFromPicture(picture: Picture): Bitmap {
     // [START android_compose_draw_into_bitmap_convert_picture]
-    val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+   /* val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         Bitmap.createBitmap(picture)
-    } else {
+    } else {*/
         val bitmap = Bitmap.createBitmap(
             picture.width,
             picture.height,
@@ -218,8 +233,8 @@ private fun createBitmapFromPicture(picture: Picture): Bitmap {
         val canvas = android.graphics.Canvas(bitmap)
         canvas.drawColor(android.graphics.Color.WHITE)
         canvas.drawPicture(picture)
-        bitmap
-    }
+     /*   bitmap
+    }*/
     // [END android_compose_draw_into_bitmap_convert_picture]
     return bitmap
 }

--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -222,9 +222,9 @@ private fun ScreenContentToCapture() {
 
 private fun createBitmapFromPicture(picture: Picture): Bitmap {
     // [START android_compose_draw_into_bitmap_convert_picture]
-   /* val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+    val bitmap = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         Bitmap.createBitmap(picture)
-    } else {*/
+    } else {
         val bitmap = Bitmap.createBitmap(
             picture.width,
             picture.height,
@@ -233,8 +233,8 @@ private fun createBitmapFromPicture(picture: Picture): Bitmap {
         val canvas = android.graphics.Canvas(bitmap)
         canvas.drawColor(android.graphics.Color.WHITE)
         canvas.drawPicture(picture)
-     /*   bitmap
-    }*/
+        bitmap
+    }
     // [END android_compose_draw_into_bitmap_convert_picture]
     return bitmap
 }

--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue

--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -179,13 +179,6 @@ fun BitmapFromComposableSnippet() {
 
 @Composable
 private fun ScreenContentToCapture() {
-    val time by produceState(0f) {
-        while (true) {
-            withInfiniteAnimationFrameMillis {
-                value = it / 1000f
-            }
-        }
-    }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
@@ -212,7 +205,6 @@ private fun ScreenContentToCapture() {
             "Into the Ocean depths",
             fontSize = 18.sp
         )
-        Text(time.toString())
     }
 }
 

--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -21,14 +21,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.createChooser
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.graphics.Picture
 import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import androidx.compose.animation.core.withInfiniteAnimationFrameMillis
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement


### PR DESCRIPTION
Fixing the following crash, where writing the `Picture` to a `Bitmap` at the same time, can cause a crash. 

Fixed by removing the offloading to a different thread. 

Nader's feedback: It is reasonable to render content into an offscreen bitmap as part of a typical render pass. The Android graphics pipeline does this internally for various use cases when content is promoted to a layer. While we should persist these bitmaps/layers across frames, doing a 1 off render if not prohibitive if done sparingly.

```
com.xxx.xxxgo.debug            A  Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x4463c00000000050 in tid 19509 (DefaultDispatch), pid 19419 (.xxxgo.debug)
pid-19635                            A  Cmdline: com.xxx.xxxgo.debug
pid-19635                            A  pid: 19419, tid: 19509, name: DefaultDispatch  >>> com.xxx.xxxgo.debug <<<
pid-19635                            A        #08 pc 000000000025a4f0  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes2.dex] (com.xxx.core_android.compose.component.CapturableState.createBitmapFromPicture+44)
pid-19635                            A        #10 pc 000000000025a4a8  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes2.dex] (com.xxx.core_android.compose.component.CapturableState.access$createBitmapFromPicture+0)
pid-19635                            A        #12 pc 0000000000259d80  [anon:dalvik-classes2.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes2.dex] (com.xxx.core_android.compose.component.CapturableState$capture$1$bitmap$1.invokeSuspend+48)
pid-19635                            A        #16 pc 0000000000340746  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.internal.LimitedDispatcher$Worker.run+10)
pid-19635                            A        #18 pc 000000000034fad2  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.scheduling.TaskImpl.run+6)
pid-19635                            A        #20 pc 000000000034eb9e  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely+2)
pid-19635                            A        #22 pc 000000000034d776  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask+34)
pid-19635                            A        #24 pc 000000000034d8a4  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker+56)
pid-19635                            A        #26 pc 000000000034d854  [anon:dalvik-classes15.dex extracted in memory from /data/app/~~nrGd_HydUC_5PO01AJmXgg==/com.xxx.xxxgo.debug-LI5DwnHiAGDWYV_C_DrcLg==/base.apk!classes15.dex] (kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run+0)
```