### PR TITLE
Update PagerSnippets.kt rectified error

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/PagerSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/PagerSnippets.kt
@@ -363,7 +363,7 @@ fun PagerWithTabs() {
 fun PagerIndicator() {
     Box {
         // [START android_compose_pager_indicator]
-        val pageCount = 10
+        val pageCount = 4
         val pagerState = rememberPagerState(pageCount = {
             4
         })
@@ -371,18 +371,20 @@ fun PagerIndicator() {
             state = pagerState
         ) { page ->
             // Our page content
-            Text(
-                text = "Page: $page",
-                modifier = Modifier
-                    .fillMaxSize()
-            )
+                Box(
+                    modifier = Modifier.background(Color.Cyan).size(400.dp)
+                ){
+                Text(
+                    text = "Page: $page",
+                )
+            }
         }
         Row(
             Modifier
                 .height(50.dp)
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter),
-            horizontalArrangement = Arrangement.Center
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.Bottom
         ) {
             repeat(pageCount) { iteration ->
                 val color = if (pagerState.currentPage == iteration) Color.DarkGray else Color.LightGray


### PR DESCRIPTION
corrected error and modified according to updated syntax

1. Modifer.align(Alignment.BottomCenter) is replaced by  verticalArrangement property which is no more working

2. wrong value 10 is replaced by 4 for pageCount 

3. made text more visible by putting it inside a box