### PR TITLE
Update ProgressIndicator.kt

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
@@ -88,7 +88,7 @@ fun LinearDeterminateIndicator() {
 
         if (loading) {
             LinearProgressIndicator(
-                progress = { currentProgress },
+                progress =  currentProgress ,
                 modifier = Modifier.fillMaxWidth(),
             )
         }


### PR DESCRIPTION
It seems there might be a mistake in the usage of the LinearProgressIndicator widget. Instead of providing a lambda function, the progress argument typically expects a float value. Consider revising the code to pass a float value directly, ensuring accurate and intended progress representation.
>
> @Composable
> @ComposableTarget
> public fun LinearProgressIndicator(
>      **progress: Float,**
>     modifier: Modifier,
>     color: Color,
>     trackColor: Color,
>     strokeCap: StrokeCap
> ): Unit