### PR TITLE
Fixed references in Typography sample.

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/text/TextDownloadableFontsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/text/TextDownloadableFontsSnippets.kt
@@ -118,16 +118,16 @@ fun DownloadableFontsText() {
 private object TextDownloadableFontsSnippet4 {
     // [START android_compose_text_typography_definition]
     val MyTypography = Typography(
-        body1 = TextStyle(
+        labelMedium = TextStyle(
             fontFamily = fontFamily, fontWeight = FontWeight.Normal, fontSize = 12.sp/*...*/
         ),
-        body2 = TextStyle(
+        labelLarge = TextStyle(
             fontFamily = fontFamily,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.sp,
             /*...*/
         ),
-        h4 = TextStyle(
+        displayMedium = TextStyle(
             fontFamily = fontFamily, fontWeight = FontWeight.SemiBold/*...*/
         ),
         /*...*/

--- a/compose/snippets/src/main/java/com/example/compose/snippets/text/TextDownloadableFontsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/text/TextDownloadableFontsSnippets.kt
@@ -21,7 +21,7 @@ package com.example.compose.snippets.text
 import android.util.Log
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
-import androidx.compose.material.Typography
+import androidx.compose.material3.Typography
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider


### PR DESCRIPTION
body1/body2/h4 don't exist in [M3 Typography](https://developer.android.com/reference/kotlin/androidx/compose/material3/Typography). The options are {display|headline|title|body|label}{Small|Medium|Large}. Changed snippet to reflect M3.