### PR TITLE
Update sync_main_latest to not using GH sync action.

### DIFF
--- a/.github/workflows/sync_main_latest.yml
+++ b/.github/workflows/sync_main_latest.yml
@@ -10,11 +10,22 @@ jobs:
     name: Syncing branches
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Opening pull request
-        id: pull
-        uses: tretuna/sync-branches@1.4.0
+        uses: actions/checkout@v3
+
+      - name: Merge main into latest
+        run: git checkout latest && git merge main
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
         with:
-          GITHUB_TOKEN: ${{secrets.PAT}}
-          FROM_BRANCH: "main"
-          TO_BRANCH: "latest"
+          token: ${{ secrets.PAT }}
+          commit-message: 🤖 Sync main to latest
+          committer: compose-devrel-github-bot <compose-devrel-github-bot@google.com>
+          author: compose-devrel-github-bot <compose-devrel-github-bot@google.com>
+          signoff: false
+          branch: bot-sync-main
+          delete-branch: true
+          title: '🤖 Sync main to latest'
+          body: Updated dependencies
+          reviewers: ${{ github.actor }}


### PR DESCRIPTION
Attempt to fix CLA issue with @compose-devrel-github-bot on the branch sync workflow.

The previous workflow for syncing `main` into `latest` would fail due to a CLA
issue with @compose-devrel-github-bot (see #199). With these changes we are
explicitly setting the git config user.email to the correct value so CLA should
pass.
