### PR TITLE
Fix sync_main_to_latest workflow

### DIFF
--- a/.github/workflows/sync_main_latest.yml
+++ b/.github/workflows/sync_main_latest.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chris/sync_main_to_latest
 
 jobs:
   sync-branches:

--- a/.github/workflows/sync_main_latest.yml
+++ b/.github/workflows/sync_main_latest.yml
@@ -1,8 +1,10 @@
 name: Sync main and latest
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
+      - chris/sync_main_to_latest
 
 jobs:
   sync-branches:
@@ -13,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Merge main into latest
-        run: git checkout latest && git merge main
+        run: git fetch && git switch latest && git merge origin/main
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
Fixed main to latest sync workflow.

Confirmed that this passes: https://github.com/android/snippets/actions/runs/7806187121/job/21292013798

Changes:
- Fix sync_to_main workflow to fetch branches before merging main to latest.
- Remove test branch.
