### PR TITLE
Use -s ours and add --allow-unrelated-histories to sync workflow.

### DIFF
--- a/.github/workflows/sync_main_latest.yml
+++ b/.github/workflows/sync_main_latest.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Merge main into latest
-        run: git fetch && git switch latest && git merge origin/main
+        run: git fetch && git switch latest && git merge -s ours origin/main --allow-unrelated-histories
 
       - name: Create pull request
         id: cpr


### PR DESCRIPTION
Fixes recent failures in the 'Sync main and latest' workflow.
