### PR TITLE
Migrate to material3-adaptive WindowSizeClass method

### DIFF
--- a/compose/snippets/build.gradle.kts
+++ b/compose/snippets/build.gradle.kts
@@ -101,7 +101,6 @@ dependencies {
 
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.runtime.livedata)
-    implementation(libs.androidx.compose.materialWindow)
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.compose.material.ripple)
     implementation(libs.androidx.constraintlayout.compose)
@@ -116,6 +115,8 @@ dependencies {
 
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.glance.material3)
+
+    implementation(libs.androidx.window.core)
 
     implementation(libs.accompanist.theme.adapter.appcompat)
     implementation(libs.accompanist.theme.adapter.material3)

--- a/compose/snippets/src/main/java/com/example/compose/snippets/glance/GlanceSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/glance/GlanceSnippets.kt
@@ -85,8 +85,8 @@ import androidx.glance.material3.ColorProviders
 import androidx.glance.text.Text
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.example.compose.snippets.MyActivity
 import com.example.compose.snippets.R
-import com.example.compose.snippets.layouts.MainActivity
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -167,11 +167,11 @@ private object CreateUI {
                 Row(horizontalAlignment = Alignment.CenterHorizontally) {
                     Button(
                         text = "Home",
-                        onClick = actionStartActivity<MainActivity>()
+                        onClick = actionStartActivity<MyActivity>()
                     )
                     Button(
                         text = "Work",
-                        onClick = actionStartActivity<MainActivity>()
+                        onClick = actionStartActivity<MyActivity>()
                     )
                 }
             }
@@ -188,7 +188,7 @@ private object ActionLaunchActivity {
         // ..
         Button(
             text = "Go Home",
-            onClick = actionStartActivity<MainActivity>()
+            onClick = actionStartActivity<MyActivity>()
         )
     }
     // [END android_compose_glance_launchactivity]

--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/AdaptiveLayoutSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/AdaptiveLayoutSnippets.kt
@@ -53,12 +53,10 @@ import androidx.window.core.layout.WindowSizeClass
 fun MyApp(
     windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
 ) {
-    // Perform logic on the size class to decide whether to show
-    // the top app bar.
+    // Perform logic on the size class to decide whether to show the top app bar.
     val showTopAppBar = windowSizeClass.windowHeightSizeClass != WindowHeightSizeClass.COMPACT
 
-    // MyScreen knows nothing about window sizes, and performs logic
-    // based on a Boolean flag.
+    // MyScreen knows nothing about window sizes, and performs logic based on a Boolean flag.
     MyScreen(
         showTopAppBar = showTopAppBar,
         /* ... */

--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/AdaptiveLayoutSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/AdaptiveLayoutSnippets.kt
@@ -18,22 +18,19 @@
 
 package com.example.compose.snippets.layouts
 
-import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
-import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowSizeClass
 
 /*
 * Copyright 2023 The Android Open Source Project
@@ -51,22 +48,14 @@ import androidx.compose.ui.unit.dp
 * limitations under the License.
 */
 // [START android_compose_adaptive_layouts_basic]
-class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContent {
-            val windowSizeClass = calculateWindowSizeClass(this)
-            MyApp(windowSizeClass)
-        }
-    }
-}
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-fun MyApp(windowSizeClass: WindowSizeClass) {
+fun MyApp(
+    windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+) {
     // Perform logic on the size class to decide whether to show
     // the top app bar.
-    val showTopAppBar = windowSizeClass.heightSizeClass != WindowHeightSizeClass.Compact
+    val showTopAppBar = windowSizeClass.windowHeightSizeClass != WindowHeightSizeClass.COMPACT
 
     // MyScreen knows nothing about window sizes, and performs logic
     // based on a Boolean flag.
@@ -94,6 +83,13 @@ fun AdaptivePane(
     }
 }
 // [END android_compose_layouts_adaptive_pane]
+
+@Composable
+private fun WindowSizeClassSnippet() {
+    // [START android_compose_windowsizeclass]
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    // [END android_compose_windowsizeclass]
+}
 
 @Composable
 fun OnePane() {

--- a/compose/snippets/src/main/java/com/example/compose/snippets/state/StateOverviewSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/state/StateOverviewSnippets.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -46,6 +45,7 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.window.core.layout.WindowSizeClass
 
 // [START android_compose_state_overview]
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-navigation = "2.7.7"
 androidx-paging = "3.2.1"
 androidx-test = "1.5.0"
 androidx-test-espresso = "3.5.1"
+androidx-window = "1.3.0-beta02"
 androidxHiltNavigationCompose = "1.2.0"
 coil = "2.5.0"
 # @keep
@@ -63,7 +64,6 @@ androidx-compose-material3-adaptive = { module = "androidx.compose.material3.ada
 androidx-compose-material3-adaptive-layout = { module = "androidx.compose.material3.adaptive:adaptive-layout", version.ref = "material3-adaptive" }
 androidx-compose-material3-adaptive-navigation = { module = "androidx.compose.material3.adaptive:adaptive-navigation", version.ref = "material3-adaptive" }
 androidx-compose-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite", version.ref = "material3-adaptive-navigation-suite" }
-androidx-compose-materialWindow = { module = "androidx.compose.material3:material3-window-size-class" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
@@ -98,6 +98,7 @@ androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
 androidx-test-runner = "androidx.test:runner:1.5.2"
+androidx-window-core = { module = "androidx.window:window-core", version.ref = "androidx-window" }
 androidx-work-runtime-ktx = "androidx.work:work-runtime-ktx:2.9.0"
 coil-kt-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 google-android-material = { module = "com.google.android.material:material", version.ref = "material" }


### PR DESCRIPTION
Updates the calculation of `WindowSizeClass` to use the new `material3-adaptive` method (which returns the `androidx.window` class) instead of the `material3-window-size-class` method.

Also adds a new snippet specifically for the calculation.