### PR TITLE
Partial bottom sheet example

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/SnippetsActivity.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/SnippetsActivity.kt
@@ -37,6 +37,7 @@ import com.example.compose.snippets.components.ComponentsScreen
 import com.example.compose.snippets.components.DialogExamples
 import com.example.compose.snippets.components.DividerExamples
 import com.example.compose.snippets.components.FloatingActionButtonExamples
+import com.example.compose.snippets.components.PartialBottomSheet
 import com.example.compose.snippets.components.ProgressIndicatorExamples
 import com.example.compose.snippets.components.ScaffoldExample
 import com.example.compose.snippets.components.SliderExamples
@@ -101,6 +102,7 @@ class SnippetsActivity : ComponentActivity() {
                                     TopComponentsDestination.CheckboxExamples -> CheckboxExamples()
                                     TopComponentsDestination.DividerExamples -> DividerExamples()
                                     TopComponentsDestination.BadgeExamples -> BadgeExamples()
+                                    TopComponentsDestination.PartialBottomSheet -> PartialBottomSheet()
                                 }
                             }
                         }

--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
@@ -1,6 +1,7 @@
 package com.example.compose.snippets.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -18,11 +19,12 @@ import androidx.compose.ui.tooling.preview.Preview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview
+// [START android_compose_components_partialbottomsheet]
 @Composable
 fun PartialBottomSheet() {
     var showBottomSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = false
+        skipPartiallyExpanded = false,
     )
 
     Column(
@@ -37,12 +39,13 @@ fun PartialBottomSheet() {
 
         if (showBottomSheet) {
             ModalBottomSheet(
+                modifier = Modifier.fillMaxHeight(),
                 sheetState = sheetState,
                 onDismissRequest = { showBottomSheet = false }
             ) {
                 Text("Swipe up to open sheet. Swipe down to dismiss.")
-                Text("Here is some placeholder content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut justo urna, facilisis vel aliquam pretium, mollis id ex. Nam sollicitudin, purus id mattis accumsan, justo eros imperdiet nisl, ac iaculis arcu nisi et ex. Praesent mi enim, luctus lobortis mauris eget, sollicitudin efficitur purus. Donec quis tellus aliquam, commodo mi feugiat, dapibus lectus.")
             }
         }
     }
 }
+// [END android_compose_components_partialbottomsheet]

--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
@@ -3,6 +3,7 @@ package com.example.compose.snippets.components
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -16,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview
@@ -43,7 +45,10 @@ fun PartialBottomSheet() {
                 sheetState = sheetState,
                 onDismissRequest = { showBottomSheet = false }
             ) {
-                Text("Swipe up to open sheet. Swipe down to dismiss.")
+                Text(
+                    "Swipe up to open sheet. Swipe down to dismiss.",
+                    modifier = Modifier.padding(16.dp)
+                )
             }
         }
     }

--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/BottomSheet.kt
@@ -1,0 +1,48 @@
+package com.example.compose.snippets.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+fun PartialBottomSheet() {
+    var showBottomSheet by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = false
+    )
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ){
+        Button(
+            onClick = { showBottomSheet = true }
+        ){
+            Text("Display partial bottom sheet")
+        }
+
+        if (showBottomSheet) {
+            ModalBottomSheet(
+                sheetState = sheetState,
+                onDismissRequest = { showBottomSheet = false }
+            ) {
+                Text("Swipe up to open sheet. Swipe down to dismiss.")
+                Text("Here is some placeholder content: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut justo urna, facilisis vel aliquam pretium, mollis id ex. Nam sollicitudin, purus id mattis accumsan, justo eros imperdiet nisl, ac iaculis arcu nisi et ex. Praesent mi enim, luctus lobortis mauris eget, sollicitudin efficitur purus. Donec quis tellus aliquam, commodo mi feugiat, dapibus lectus.")
+            }
+        }
+    }
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/navigation/Destination.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/navigation/Destination.kt
@@ -40,4 +40,5 @@ enum class TopComponentsDestination(val route: String, val title: String) {
     CheckboxExamples("checkboxExamples", "Checkbox"),
     DividerExamples("dividerExamples", "Dividers"),
     BadgeExamples("badgeExamples", "Badges"),
+    PartialBottomSheet("partialBottomSheets", "Partial Bottom Sheet"),
 }


### PR DESCRIPTION
Adding an example where a bottom sheet is initially displayed only over part of the screen. The user can then swipe to fill the screen with it, or dismiss it.