### PR TITLE
Adds sample for rotary and timepicker

### DIFF
--- a/wear/src/main/java/com/example/wear/snippets/MainActivity.kt
+++ b/wear/src/main/java/com/example/wear/snippets/MainActivity.kt
@@ -20,10 +20,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
-import com.example.wear.snippets.navigation.navigation
-import com.example.wear.snippets.voiceinput.VoiceInputScreen
+import com.example.wear.snippets.rotary.TimePicker
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
-import com.google.android.horologist.compose.layout.AppScaffold
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,7 +39,6 @@ class MainActivity : ComponentActivity() {
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun WearApp() {
-    AppScaffold {
-        navigation()
-    }
+    // insert here the snippet you want to test
+    TimePicker()
 }

--- a/wear/src/main/java/com/example/wear/snippets/navigation/Navigation.kt
+++ b/wear/src/main/java/com/example/wear/snippets/navigation/Navigation.kt
@@ -34,6 +34,7 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import com.example.wear.R
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumn
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
@@ -44,8 +45,9 @@ import com.google.android.horologist.compose.material.ListHeaderDefaults.firstIt
 import com.google.android.horologist.compose.material.ResponsiveListHeader
 import com.google.android.horologist.compose.rotaryinput.rotaryWithScroll
 
-    @Composable
-    fun navigation() {
+@Composable
+fun navigation() {
+    AppScaffold {
         // [START android_wear_navigation]
         val navController = rememberSwipeDismissableNavController()
         SwipeDismissableNavHost(
@@ -63,10 +65,11 @@ import com.google.android.horologist.compose.rotaryinput.rotaryWithScroll
         }
         // [END android_wear_navigation]
     }
+}
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
-fun MessageDetail(id: String){
+fun MessageDetail(id: String) {
     val scrollState = rememberScrollState()
 
     ScreenScaffold(scrollState = scrollState) {
@@ -82,16 +85,18 @@ fun MessageDetail(id: String){
                 .padding(padding),
             verticalArrangement = Arrangement.Center
         ) {
-            Text(text= id,
+            Text(
+                text = id,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxSize())
+                modifier = Modifier.fillMaxSize()
+            )
         }
     }
 }
 
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
-fun MessageList(onMessageClick: (String) -> Unit){
+fun MessageList(onMessageClick: (String) -> Unit) {
     val columnState = rememberResponsiveColumnState(
         contentPadding = ScalingLazyColumnDefaults.padding(
             first = ItemType.Text,
@@ -111,10 +116,10 @@ fun MessageList(onMessageClick: (String) -> Unit){
                 }
             }
             item {
-                Chip(label = "Message 1", onClick = { onMessageClick("message1")})
+                Chip(label = "Message 1", onClick = { onMessageClick("message1") })
             }
             item {
-                Chip(label = "Message 2", onClick = { onMessageClick("message2")})
+                Chip(label = "Message 2", onClick = { onMessageClick("message2") })
             }
         }
     }
@@ -133,4 +138,3 @@ fun MessageDetailPreview() {
 fun MessageListPreview() {
     MessageList(onMessageClick = {})
 }
-

--- a/wear/src/main/java/com/example/wear/snippets/rotary/Rotary.kt
+++ b/wear/src/main/java/com/example/wear/snippets/rotary/Rotary.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.wear.snippets.rotary
+
+import android.view.MotionEvent
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.ExperimentalWearFoundationApi
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.foundation.rememberActiveFocusRequester
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Picker
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberPickerState
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalWearFoundationApi::class)
+@Composable
+fun ScrollableScreen() {
+    // This sample doesn't add a Time Text at the top of the screen.
+    // If using Time Text, add padding to ensure content does not overlap with Time Text.
+    // [START android_wear_rotary_input]
+    val listState = rememberScalingLazyListState()
+    Scaffold(
+        positionIndicator = {
+            PositionIndicator(scalingLazyListState = listState)
+        }
+    ) {
+
+        val focusRequester = rememberActiveFocusRequester()
+        val coroutineScope = rememberCoroutineScope()
+
+        ScalingLazyColumn(
+            modifier = Modifier
+                .onRotaryScrollEvent {
+                    coroutineScope.launch {
+                        listState.scrollBy(it.verticalScrollPixels)
+                        listState.animateScrollBy(0f)
+                    }
+                    true
+                }
+                .focusRequester(focusRequester)
+                .focusable()
+                .fillMaxSize(),
+            state = listState
+        ) {
+            // Content goes here
+            // [START_EXCLUDE]
+            items(count = 5) {
+                Chip(onClick = { }, label = { Text("Item #$it") })
+            }
+            // [END_EXCLUDE]
+        }
+    }
+    // [END android_wear_rotary_input]
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun TimePicker() {
+    val textStyle = MaterialTheme.typography.display1
+
+    // [START android_wear_rotary_input_picker]
+    var selectedColumn by remember { mutableIntStateOf(0) }
+
+    val hoursFocusRequester = remember { FocusRequester() }
+    val minutesRequester = remember { FocusRequester() }
+    // [START_EXCLUDE]
+    val coroutineScope = rememberCoroutineScope()
+
+    @Composable
+    fun Option(column: Int, text: String) = Box(modifier = Modifier.fillMaxSize()) {
+        Text(
+            text = text, style = textStyle,
+            color = if (selectedColumn == column) MaterialTheme.colors.secondary
+            else MaterialTheme.colors.onBackground,
+            modifier = Modifier
+                .pointerInteropFilter {
+                    if (it.action == MotionEvent.ACTION_DOWN) selectedColumn = column
+                    true
+                }
+        )
+    }
+    // [END_EXCLUDE]
+    Scaffold(modifier = Modifier.fillMaxSize()) {
+        Row(
+            // [START_EXCLUDE]
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            // [END_EXCLUDE]
+            // ...
+        ) {
+            // [START_EXCLUDE]
+            val hourState = rememberPickerState(
+                initialNumberOfOptions = 12,
+                initiallySelectedOption = 5
+            )
+            val hourContentDescription by remember {
+                derivedStateOf { "${hourState.selectedOption + 1 } hours" }
+            }
+            // [END_EXCLUDE]
+            Picker(
+                readOnly = selectedColumn != 0,
+                modifier = Modifier.size(64.dp, 100.dp)
+                    .onRotaryScrollEvent {
+                        coroutineScope.launch {
+                            hourState.scrollBy(it.verticalScrollPixels)
+                        }
+                        true
+                    }
+                    .focusRequester(hoursFocusRequester)
+                    .focusable(),
+                onSelected = { selectedColumn = 0 },
+                // ...
+                // [START_EXCLUDE]
+                state = hourState,
+                contentDescription = hourContentDescription,
+                option = { hour: Int -> Option(0, "%2d".format(hour + 1)) }
+                // [END_EXCLUDE]
+            )
+            // [START_EXCLUDE]
+            Spacer(Modifier.width(8.dp))
+            Text(text = ":", style = textStyle, color = MaterialTheme.colors.onBackground)
+            Spacer(Modifier.width(8.dp))
+            val minuteState =
+                rememberPickerState(initialNumberOfOptions = 60, initiallySelectedOption = 0)
+            val minuteContentDescription by remember {
+                derivedStateOf { "${minuteState.selectedOption} minutes" }
+            }
+            // [END_EXCLUDE]
+            Picker(
+                readOnly = selectedColumn != 1,
+                modifier = Modifier.size(64.dp, 100.dp)
+                    .onRotaryScrollEvent {
+                        coroutineScope.launch {
+                            minuteState.scrollBy(it.verticalScrollPixels)
+                        }
+                        true
+                    }
+                    .focusRequester(minutesRequester)
+                    .focusable(),
+                onSelected = { selectedColumn = 1 },
+                // ...
+                // [START_EXCLUDE]
+                state = minuteState,
+                contentDescription = minuteContentDescription,
+                option = { minute: Int -> Option(1, "%02d".format(minute)) }
+                // [END_EXCLUDE]
+            )
+            LaunchedEffect(selectedColumn) {
+                listOf(
+                    hoursFocusRequester,
+                    minutesRequester
+                )[selectedColumn]
+                    .requestFocus()
+            }
+        }
+    }
+    // [END android_wear_rotary_input_picker]
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun ScrollableScreenPreview() {
+    ScrollableScreen()
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun TimePickerPreview() {
+    TimePicker()
+}

--- a/wear/src/main/java/com/example/wear/snippets/voiceinput/VoiceInputScreen.kt
+++ b/wear/src/main/java/com/example/wear/snippets/voiceinput/VoiceInputScreen.kt
@@ -49,8 +49,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import com.example.wear.R
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.layout.AppScaffold
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults
 import com.google.android.horologist.compose.layout.ScalingLazyColumnDefaults.ItemType
 import com.google.android.horologist.compose.layout.ScreenScaffold
@@ -63,63 +66,72 @@ import com.google.android.horologist.compose.rotaryinput.rotaryWithScroll
 @OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun VoiceInputScreen() {
-    // [START android_wear_voice_input]
-    var textForVoiceInput by remember { mutableStateOf("") }
+    AppScaffold {
+        // [START android_wear_voice_input]
+        var textForVoiceInput by remember { mutableStateOf("") }
 
-    val voiceLauncher =
-        rememberLauncherForActivityResult(
-            ActivityResultContracts.StartActivityForResult()
-        ) { activityResult ->
-            // This is where you process the intent and extract the speech text from the intent.
-            activityResult.data?.let { data ->
-                val results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
-                textForVoiceInput = results?.get(0) ?: "None"
+        val voiceLauncher =
+            rememberLauncherForActivityResult(
+                ActivityResultContracts.StartActivityForResult()
+            ) { activityResult ->
+                // This is where you process the intent and extract the speech text from the intent.
+                activityResult.data?.let { data ->
+                    val results = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                    textForVoiceInput = results?.get(0) ?: "None"
+                }
             }
-        }
 
-    val scrollState = rememberScrollState()
+        val scrollState = rememberScrollState()
 
-    ScreenScaffold(scrollState = scrollState) {
-        //rest of implementation here
-        // [START_EXCLUDE]
-        val padding = ScalingLazyColumnDefaults.padding(
-            first = ItemType.Text,
-            last = ItemType.Chip
-        )()
-        // [END_EXCLUDE]
-        Column(
-            //rest of implementation here
+        ScreenScaffold(scrollState = scrollState) {
+            // rest of implementation here
             // [START_EXCLUDE]
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState)
-                .rotaryWithScroll(scrollState)
-                .padding(padding),
-            verticalArrangement = Arrangement.Center
-        ) {
+            val padding = ScalingLazyColumnDefaults.padding(
+                first = ItemType.Text,
+                last = ItemType.Chip
+            )()
             // [END_EXCLUDE]
+            Column(
+                // rest of implementation here
+                // [START_EXCLUDE]
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .rotaryWithScroll(scrollState)
+                    .padding(padding),
+                verticalArrangement = Arrangement.Center
+            ) {
+                // [END_EXCLUDE]
 
-            // Create an intent that can start the Speech Recognizer activity
-            val voiceIntent: Intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-                putExtra(
-                    RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-                    RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
-                )
+                // Create an intent that can start the Speech Recognizer activity
+                val voiceIntent: Intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                    putExtra(
+                        RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                        RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
+                    )
 
-                putExtra(
-                    RecognizerIntent.EXTRA_PROMPT,
-                    stringResource(R.string.voice_text_entry_label)
+                    putExtra(
+                        RecognizerIntent.EXTRA_PROMPT,
+                        stringResource(R.string.voice_text_entry_label)
+                    )
+                }
+                // Invoke the process from a chip
+                Chip(
+                    onClick = {
+                        voiceLauncher.launch(voiceIntent)
+                    },
+                    label = stringResource(R.string.voice_input_label),
+                    secondaryLabel = textForVoiceInput
                 )
             }
-            // Invoke the process from a chip
-            Chip(
-                onClick = {
-                    voiceLauncher.launch(voiceIntent)
-                },
-                label = stringResource(R.string.voice_input_label),
-                secondaryLabel = textForVoiceInput
-            )
         }
+        // [END android_wear_voice_input]
     }
-    // [END android_wear_voice_input]
+}
+
+@WearPreviewDevices
+@WearPreviewFontScales
+@Composable
+fun VoiceInputScreenPreview() {
+    VoiceInputScreen()
 }


### PR DESCRIPTION
This PR partially fixes https://developer.android.com/training/wearables/compose/rotary-input:
- Adds an example for a scrollable screen where rotary can be used to scroll
- Adds an example for a TimePicker to demonstrate how to use rotary on a Picker + focus

A follow up PR will add the remaining part of the DAC page.