### PR TITLE
Center TopAppBar snippet to use centerAlignedTopAppBarColor

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/AppBar.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/AppBar.kt
@@ -204,7 +204,7 @@ fun CenterAlignedTopAppBarExample() {
 
         topBar = {
             CenterAlignedTopAppBar(
-                colors = TopAppBarDefaults.topAppBarColors(
+                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.primary,
                 ),


### PR DESCRIPTION
Update the CenterAlignedTopAppBar () snippet to use the centerAlignedTopAppBarColor function defined here: 

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/AppBar.kt;l=1413