### PR TITLE
Update Compose Navigation snippets to include type safe APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kapt) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }
 
 apply("${project.rootDir}/buildscripts/toml-updater-config.gradle")

--- a/compose/snippets/build.gradle.kts
+++ b/compose/snippets/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     alias(libs.plugins.kapt)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -138,6 +139,7 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.androidx.recyclerview)
 

--- a/compose/snippets/src/main/java/com/example/compose/snippets/interop/MigrationCommonScenariosSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/interop/MigrationCommonScenariosSnippets.kt
@@ -64,10 +64,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 
 class RVActivity : ComponentActivity() {
     private lateinit var composeView: ComposeView
@@ -141,6 +143,13 @@ class SampleActivity : ComponentActivity() {
 }
 // [END android_compose_interop_migration_common_scenarios_navigation_step_2]
 
+// [START android_compose_interop_migration_common_scenarios_navigation_step_2_1]
+@Serializable data object First
+@Serializable data class Second(val id: String)
+@Serializable data object Third
+
+// [END android_compose_interop_migration_common_scenarios_navigation_step_2_1]
+
 private object MigrationCommonScenariosNavigationStep3 {
     // [START android_compose_interop_migration_common_scenarios_navigation_step_3]
     @Composable
@@ -164,7 +173,7 @@ private object MigrationCommonScenariosNavigationStep4 {
     fun SampleNavHost(
         navController: NavHostController
     ) {
-        NavHost(navController = navController, startDestination = "first") {
+        NavHost(navController = navController, startDestination = First) {
             // ...
         }
     }
@@ -191,11 +200,11 @@ class FirstFragment : Fragment() {
 fun SampleNavHost(
     navController: NavHostController
 ) {
-    NavHost(navController = navController, startDestination = "first") {
-        composable("first") {
+    NavHost(navController = navController, startDestination = First) {
+        composable<First> {
             FirstScreen(/* ... */) // EXTRACT TO HERE
         }
-        composable("second") {
+        composable<Second> {
             SecondScreen(/* ... */)
         }
         // ...
@@ -220,20 +229,22 @@ private object MigrationCommonScenariosNavigationStep7 {
     fun SampleNavHost(
         navController: NavHostController
     ) {
-        NavHost(navController = navController, startDestination = "first") {
-            composable("first") {
+        NavHost(navController = navController, startDestination = First) {
+            composable<First> {
                 FirstScreen(
                     onButtonClick = {
                         // findNavController().navigate(firstScreenToSecondScreenAction)
-                        navController.navigate("second_screen_route")
+                        navController.navigate(Second(id = "ABC"))
                     }
                 )
             }
-            composable("second") {
+            composable<Second> { backStackEntry ->
+                val secondRoute = backStackEntry.toRoute<Second>()
                 SecondScreen(
+                    id = secondRoute.id,
                     onIconClick = {
                         // findNavController().navigate(secondScreenToThirdScreenAction)
-                        navController.navigate("third_screen_route")
+                        navController.navigate(Third)
                     }
                 )
             }
@@ -410,6 +421,7 @@ fun SampleApp() {
 
 @Composable
 fun SecondScreen(
+    id: String = "<no ID supplied>",
     onIconClick: () -> Unit = {},
 ) {
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidx-window = "1.3.0-beta02"
 androidxHiltNavigationCompose = "1.2.0"
 coil = "2.5.0"
 # @keep
-compileSdk = "34"
+compileSdk = "35"
 compose-compiler = "1.5.4"
 coreSplashscreen = "1.0.1"
 coroutines = "1.7.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ horologist = "0.5.24"
 junit = "4.13.2"
 # @pin Update in conjuction with Compose Compiler
 kotlin = "1.9.20"
-kotlinxSerializationJson = "1.7.1"
+kotlinxSerializationJson = "1.6.3"
 ksp = "1.8.0-1.0.9"
 maps-compose = "4.3.2"
 material = "1.4.0-beta01"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidx-fragment-ktx = "1.6.2"
 androidx-glance-appwidget = "1.0.0"
 androidx-lifecycle-compose = "2.8.0-rc01"
 androidx-lifecycle-runtime-compose = "2.8.0-rc01"
-androidx-navigation = "2.7.7"
+androidx-navigation = "2.8.0-beta07"
 androidx-paging = "3.2.1"
 androidx-test = "1.5.0"
 androidx-test-espresso = "3.5.1"
@@ -33,6 +33,7 @@ horologist = "0.5.24"
 junit = "4.13.2"
 # @pin Update in conjuction with Compose Compiler
 kotlin = "1.9.20"
+kotlinxSerializationJson = "1.7.1"
 ksp = "1.8.0-1.0.9"
 maps-compose = "4.3.2"
 material = "1.4.0-beta01"
@@ -121,6 +122,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "playServicesWearable" }
 compose-ui-tooling = { group = "androidx.wear.compose", name = "compose-ui-tooling", version.ref = "composeUiTooling" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
@@ -133,4 +135,5 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update" }


### PR DESCRIPTION
**What have I done and why**
Updated the snippets for Fragments -> Compose navigation migration to include the new type safe APIs introduced in Navigation 2.8.0. 

Accompanying docs CL: cl/664965811

Please do not merge as I need to sync the CL and PR submissions once both are approved.