### PR TITLE
Fixes region tags.

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/text/TextSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/text/TextSnippets.kt
@@ -856,7 +856,7 @@ private val firaSansFamily = FontFamily()
 val LightBlue = Color(0xFF0066FF)
 val Purple = Color(0xFF800080)
 
-// [START android_compose_text_auto_format_phone_number_showhidepassword]
+// [START android_compose_text_showhidepassword]
 @Composable
 fun PasswordTextField() {
     var password by rememberSaveable { mutableStateOf("") }
@@ -887,4 +887,4 @@ fun PasswordTextField() {
         }
     )
 }
-// [END android_compose_text_auto_format_phone_number_showhidepassword]
+// [END android_compose_text_showhidepassword]


### PR DESCRIPTION
Existing region tag is a bit misleading, as it suggests it's related to phone numbers (maybe from a copy-paste?). I've removed that text to make the region tag more accurately self-documenting. Afaik, the relevant code segment is orthogonal to phone numbers.