### PR TITLE
Add snippets for ARCore for Jetpack XR Overview page: anchors, persistent anchors, planes

### DIFF
--- a/xr/src/main/java/com/example/xr/arcore/AnchorPersistence.kt
+++ b/xr/src/main/java/com/example/xr/arcore/AnchorPersistence.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.xr.arcore
+
+import androidx.xr.arcore.Anchor
+import androidx.xr.arcore.AnchorCreateSuccess
+import androidx.xr.runtime.Session
+import java.util.UUID
+
+private suspend fun persistAnchor(anchor: Anchor) {
+    // [START androidxr_arcore_anchor_persist]
+    val uuid = anchor.persist()
+    // [END androidxr_arcore_anchor_persist]
+}
+
+private fun loadAnchor(session: Session, uuid: UUID) {
+    // [START androidxr_arcore_anchor_load]
+    when (val result = Anchor.load(session, uuid)) {
+        is AnchorCreateSuccess -> {
+            // Loading was successful. The anchor is stored in result.anchor.
+        }
+        else -> {
+            // handle failure
+        }
+    }
+    // [END androidxr_arcore_anchor_load]
+}
+
+private fun unpersistAnchor(session: Session, uuid: UUID) {
+    // [START androidxr_arcore_anchor_unpersist]
+    Anchor.unpersist(session, uuid)
+    // [END androidxr_arcore_anchor_unpersist]
+}
+
+private fun getPersistedAnchorUuids(session: Session) {
+    // [START androidxr_arcore_anchor_get_uuids]
+    val uuids = Anchor.getPersistedAnchorUuids(session)
+    // [END androidxr_arcore_anchor_get_uuids]
+}

--- a/xr/src/main/java/com/example/xr/arcore/Anchors.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Anchors.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.xr.arcore
+
+import androidx.xr.arcore.Anchor
+import androidx.xr.arcore.AnchorCreateSuccess
+import androidx.xr.arcore.Trackable
+import androidx.xr.runtime.Session
+import androidx.xr.runtime.math.Pose
+import androidx.xr.scenecore.AnchorEntity
+import androidx.xr.scenecore.Entity
+
+private fun createAnchorAtPose(session: Session, pose: Pose) {
+    val pose = Pose()
+    // [START androidxr_arcore_anchor_create]
+    when (val result = Anchor.create(session, pose)) {
+        is AnchorCreateSuccess -> { /* anchor stored in `result.anchor`. */ }
+        else -> { /* handle failure */ }
+    }
+    // [END androidxr_arcore_anchor_create]
+}
+
+private fun createAnchorAtTrackable(trackable: Trackable<*>) {
+    val pose = Pose()
+    // [START androidxr_arcore_anchor_create_trackable]
+    when (val result = trackable.createAnchor(pose)) {
+        is AnchorCreateSuccess -> { /* anchor stored in `result.anchor`. */ }
+        else -> { /* handle failure */ }
+    }
+    // [END androidxr_arcore_anchor_create_trackable]
+}
+
+private fun attachEntityToAnchor(
+    session: androidx.xr.scenecore.Session,
+    entity: Entity,
+    anchor: Anchor
+) {
+    // [START androidxr_arcore_entity_tracks_anchor]
+    AnchorEntity.create(session, anchor).apply {
+        setParent(session.activitySpace)
+        addChild(entity)
+    }
+    // [END androidxr_arcore_entity_tracks_anchor]
+}

--- a/xr/src/main/java/com/example/xr/arcore/Planes.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Planes.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.xr.arcore
+
+import androidx.xr.arcore.Plane
+import androidx.xr.runtime.Session
+import androidx.xr.runtime.math.Pose
+import androidx.xr.runtime.math.Ray
+
+private suspend fun subscribePlanes(session: Session) {
+    // [START androidxr_arcore_planes_subscribe]
+    Plane.subscribe(session).collect { planes ->
+        // Planes have changed; update plane rendering
+    }
+    // [END androidxr_arcore_planes_subscribe]
+}
+
+private fun hitTestTable(session: Session) {
+    val scenecoreSession: androidx.xr.scenecore.Session = null!!
+    val pose = scenecoreSession.spatialUser.head?.transformPoseTo(Pose(), scenecoreSession.perceptionSpace) ?: return
+    val ray = Ray(pose.translation, pose.forward)
+    // [START androidxr_arcore_hitTest]
+    val results = androidx.xr.arcore.hitTest(session, ray)
+    // When interested in the first Table hit:
+    val tableHit = results.firstOrNull {
+        val trackable = it.trackable
+        trackable is Plane && trackable.state.value.label == Plane.Label.Table
+    }
+    // [END androidxr_arcore_hitTest]
+}


### PR DESCRIPTION
Migrates most snippets from [this page](https://developer.android.com/develop/xr/jetpack-xr-sdk/work-with-arcore).