### PR TITLE
fix: remove silent from END_EXCLUDE

### DIFF
--- a/xr/src/main/java/com/example/xr/compose/Volume.kt
+++ b/xr/src/main/java/com/example/xr/compose/Volume.kt
@@ -68,7 +68,7 @@ fun ObjectInAVolume(show3DObject: Boolean) {
     val volumeXOffset = 0.dp
     val volumeYOffset = 0.dp
     val volumeZOffset = 0.dp
-    // [END_EXCLUDE silent]
+    // [END_EXCLUDE]
     val session = checkNotNull(LocalSession.current)
     val scope = rememberCoroutineScope()
     if (show3DObject) {


### PR DESCRIPTION
I found a snipet broken in [AndroidXR doc page](https://developer.android.com/develop/xr/jetpack-xr-sdk/develop-ui?_gl=1*k9htv7*_up*MQ..*_ga*NDkzMTgyMjQ3LjE3NDczMjY2OTY.*_ga_6HH9YJMN9M*czE3NDczMjY2OTYkbzEkZzAkdDE3NDczMjY2OTYkajAkbDAkaDc3Mzg3OTc0Ng..#use-volume)

![image](https://github.com/user-attachments/assets/e6d2efe7-0350-481d-abdd-c03e9e11b479)
