### PR TITLE
Fixing compile error in DeviceCompatibilityModeTestJavaSnippets

### DIFF
--- a/misc/src/androidTest/java/com/example/snippets/DeviceCompatibilityModeTestJavaSnippets.java
+++ b/misc/src/androidTest/java/com/example/snippets/DeviceCompatibilityModeTestJavaSnippets.java
@@ -16,7 +16,6 @@
 
 package com.example.snippets;
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import org.junit.Rule;
@@ -42,7 +41,7 @@ public class DeviceCompatibilityModeTestJavaSnippets {
 
 
     // Method used by snippets.
-    public boolean isLetterboxed(AppCompatActivity activity) {
+    public boolean isLetterboxed(MainActivity activity) {
         return true;
     }
 


### PR DESCRIPTION
Happened to notice a typo in the file, but it still didn't compile when I fixed the typo, so I made a second fix.

The typo was a missing semicolon at the "import AppCompatActivity" line. But after I fixed that, I got an error complaining about `assertFalse(isLetterboxed(activity))` because `isLetterboxed` is expecting an AppCompatActivity but `activity` is a `MainActivity`. Changing `isLetterboxed` fixed the compile error and also meant we don't import AppCompatActivity so the original typo goes away. [shrug emoji]

Is this fix okay?