### PR TITLE
Adding code snippets for wake locks doc

### DIFF
--- a/misc/src/main/java/com/example/snippets/backgroundwork/MyException.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/MyException.java
@@ -1,0 +1,13 @@
+package com.example.snippets.backgroundwork;
+
+/**
+ * Placeholder exception used by wake lock docs.
+ *
+ * Existing wake lock code snippets inclde a method that throws "MyException", I need to define
+ * it for the code snippets to use.
+ */
+public class MyException extends RuntimeException {
+    public MyException(String message) {
+        super(message);
+    }
+}

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
@@ -17,7 +17,7 @@ public class WakeLockSnippetsJava extends Activity {
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag");
         wakeLock.acquire();
-        // [END android_backgroundwork_wakelock_create_kotlin]
+        // [END android_backgroundwork_wakelock_create_java]
 
         super.onCreate(savedInstanceState);
     }

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
@@ -1,0 +1,38 @@
+package com.example.snippets.backgroundwork;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.PowerManager;
+
+import androidx.annotation.Nullable;
+
+public class WakeLockSnippetsJava extends Activity {
+
+    PowerManager.WakeLock wakeLock;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+
+        // [START android_backgroundwork_wakelock_create_java]
+        PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+        PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag");
+        wakeLock.acquire();
+        // [END android_backgroundwork_wakelock_create_kotlin]
+
+        super.onCreate(savedInstanceState);
+    }
+
+    // [START android_backgroundwork_wakelock_release_java]
+    void doSomethingAndRelease() throws MyException {
+        try {
+            wakeLock.acquire();
+            doTheWork();
+        } finally {
+            wakeLock.release();
+        }
+    }
+    // [END android_backgroundwork_wakelock_release_java]
+
+    private void doTheWork() {
+    }
+}

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.backgroundwork
 
 import android.app.Activity
@@ -14,12 +30,10 @@ class WakeLockSnippetsKotlin : Activity() {
             newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag").apply {
                 acquire()
             }
-
         }
     // [END android_backgroundwork_wakelock_create_kotlin]
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
 
         super.onCreate(savedInstanceState)
     }
@@ -39,7 +53,5 @@ class WakeLockSnippetsKotlin : Activity() {
     // [END android_backgroundwork_wakelock_release_kotlin]
 
     private fun doTheWork() {
-
     }
-
 }

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
@@ -1,0 +1,45 @@
+package com.example.snippets.backgroundwork
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import android.os.PowerManager
+
+// Snippets for doc page go here
+class WakeLockSnippetsKotlin : Activity() {
+
+    // [START android_backgroundwork_wakelock_create_kotlin]
+    val wakeLock: PowerManager.WakeLock =
+        (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
+            newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag").apply {
+                acquire()
+            }
+
+        }
+    // [END android_backgroundwork_wakelock_create_kotlin]
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+
+
+        super.onCreate(savedInstanceState)
+    }
+
+    // [START android_backgroundwork_wakelock_release_kotlin]
+    @Throws(MyException::class)
+    fun doSomethingAndRelease() {
+        wakeLock.apply {
+            try {
+                acquire()
+                doTheWork()
+            } finally {
+                release()
+            }
+        }
+    }
+    // [END android_backgroundwork_wakelock_release_kotlin]
+
+    private fun doTheWork() {
+
+    }
+
+}


### PR DESCRIPTION
Starting with the code snippets to add and release a wake lock, we can add other snippets later.

Used by docs in:

https://developer.android.com/develop/background-work/background-tasks/awake/wakelock/

The actual snippets used on the DAC pages are bracketed by the `[START ...]` and `[END ...]` comments; everything else is just scaffolding to get the snippet to compile.