### PR TITLE
Breaking long line in code snippet

### DIFF
--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
@@ -15,7 +15,8 @@ public class WakeLockSnippetsJava extends Activity {
 
         // [START android_backgroundwork_wakelock_create_java]
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
-        PowerManager.WakeLock wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag");
+        PowerManager.WakeLock wakeLock =
+                powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag");
         wakeLock.acquire();
         // [END android_backgroundwork_wakelock_create_java]
 


### PR DESCRIPTION
When I pull the Java "acquire wake lock" snippet into the DAC page, one code line is too long. Breaking that line at the assignment operator so the page user doesn't have to scroll horizontally.