### PR TITLE
Lint: Use specialized state holders to avoid autoboxing

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/Badges.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/Badges.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -78,7 +79,7 @@ fun BadgeExample() {
 // [START android_compose_components_badgeinteractive]
 @Composable
 fun BadgeInteractiveExample() {
-    var itemCount by remember { mutableStateOf(0) }
+    var itemCount by remember { mutableIntStateOf(0) }
 
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp)

--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -65,7 +66,7 @@ fun ProgressIndicatorExamples() {
 // [START android_compose_components_determinateindicator]
 @Composable
 fun LinearDeterminateIndicator() {
-    var currentProgress by remember { mutableStateOf(0f) }
+    var currentProgress by remember { mutableFloatStateOf(0f) }
     var loading by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope() // Create a coroutine scope
 
@@ -107,7 +108,7 @@ suspend fun loadProgress(updateProgress: (Float) -> Unit) {
 @Preview
 @Composable
 fun CircularDeterminateIndicator() {
-    var currentProgress by remember { mutableStateOf(0f) }
+    var currentProgress by remember { mutableFloatStateOf(0f) }
     var loading by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope() // Create a coroutine scope
 

--- a/compose/snippets/src/main/java/com/example/compose/snippets/glance/GlanceSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/glance/GlanceSnippets.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -655,7 +656,7 @@ object CompoundButton {
         // [START android_compose_glance_buildUI12]
         var isApplesChecked by remember { mutableStateOf(false) }
         var isEnabledSwitched by remember { mutableStateOf(false) }
-        var isRadioChecked by remember { mutableStateOf(0) }
+        var isRadioChecked by remember { mutableIntStateOf(0) }
 
         CheckBox(
             checked = isApplesChecked,

--- a/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/graphics/AdvancedGraphicsSnippets.kt
@@ -66,10 +66,10 @@ import androidx.core.content.ContextCompat.startActivity
 import com.example.compose.snippets.R
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberMultiplePermissionsState
-import java.io.File
-import kotlin.coroutines.resume
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.io.File
+import kotlin.coroutines.resume
 
 /*
 * Copyright 2022 The Android Open Source Project

--- a/compose/snippets/src/main/java/com/example/compose/snippets/interop/InteroperabilityAPIsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/interop/InteroperabilityAPIsSnippets.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -194,7 +195,7 @@ class ExampleFragmentMultipleComposeView : Fragment() {
 // [START android_compose_interop_apis_views_in_compose]
 @Composable
 fun CustomView() {
-    var selectedItem by remember { mutableStateOf(0) }
+    var selectedItem by remember { mutableIntStateOf(0) }
 
     // Adds view to Compose
     AndroidView(

--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/FlowLayoutSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/FlowLayoutSnippets.kt
@@ -45,6 +45,7 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -472,7 +473,7 @@ fun ContextualFlowLayoutExample() {
     // [START android_compose_layouts_contextual_flow]
     val totalCount = 40
     var maxLines by remember {
-        mutableStateOf(2)
+        mutableIntStateOf(2)
     }
 
     val moreOrCollapseIndicator = @Composable { scope: ContextualFlowRowOverflowScope ->

--- a/compose/snippets/src/main/java/com/example/compose/snippets/performance/PerformanceSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/performance/PerformanceSnippets.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -264,7 +265,7 @@ private object BackwardsWrite {
     // [START android_compose_performance_backwardswrite]
     @Composable
     fun BadComposable() {
-        var count by remember { mutableStateOf(0) }
+        var count by remember { mutableIntStateOf(0) }
 
         // Causes recomposition on click
         Button(onClick = { count++ }, Modifier.wrapContentSize()) {

--- a/compose/snippets/src/main/java/com/example/compose/snippets/phases/PhasesSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/phases/PhasesSnippets.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -178,7 +179,7 @@ private object Loop {
     fun Loop() {
         // [START android_compose_phases_loop]
         Box {
-            var imageHeightPx by remember { mutableStateOf(0) }
+            var imageHeightPx by remember { mutableIntStateOf(0) }
 
             Image(
                 painter = painterResource(R.drawable.rectangle),

--- a/compose/snippets/src/main/java/com/example/compose/snippets/sideeffects/SideEffectsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/sideeffects/SideEffectsSnippets.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -59,7 +60,7 @@ fun MyScreen() {
 // [START android_compose_side_effects_launchedeffect]
     // Allow the pulse rate to be configured, so it can be sped up if the user is running
     // out of time
-    var pulseRateMs by remember { mutableStateOf(3000L) }
+    var pulseRateMs by remember { mutableLongStateOf(3000L) }
     val alpha = remember { Animatable(1f) }
     LaunchedEffect(pulseRateMs) { // Restart the effect when the pulse rate changes
         while (isActive) {

--- a/compose/snippets/src/main/java/com/example/compose/snippets/touchinput/gestures/GesturesSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/touchinput/gestures/GesturesSnippets.kt
@@ -52,6 +52,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -77,7 +79,7 @@ import kotlin.math.roundToInt
 // [START android_compose_touchinput_gestures_clickable]
 @Composable
 private fun ClickableSample() {
-    val count = remember { mutableStateOf(0) }
+    val count = remember { mutableIntStateOf(0) }
     // content that you want to make clickable
     Text(
         text = count.value.toString(),
@@ -89,7 +91,7 @@ private fun ClickableSample() {
 @Preview
 @Composable
 private fun WithPointerInput() {
-    val count = remember { mutableStateOf(0) }
+    val count = remember { mutableIntStateOf(0) }
     // content that you want to make clickable
     Text(
         text = count.value.toString(),
@@ -151,7 +153,7 @@ private fun ScrollBoxesSmooth() {
 @Composable
 private fun ScrollableSample() {
     // actual composable state
-    var offset by remember { mutableStateOf(0f) }
+    var offset by remember { mutableFloatStateOf(0f) }
     Box(
         Modifier
             .size(150.dp)
@@ -249,7 +251,7 @@ private object NestedScrollInterop {
 // [START android_compose_touchinput_gestures_draggable]
 @Composable
 private fun DraggableText() {
-    var offsetX by remember { mutableStateOf(0f) }
+    var offsetX by remember { mutableFloatStateOf(0f) }
     Text(
         modifier = Modifier
             .offset { IntOffset(offsetX.roundToInt(), 0) }
@@ -268,8 +270,8 @@ private fun DraggableText() {
 @Composable
 private fun DraggableTextLowLevel() {
     Box(modifier = Modifier.fillMaxSize()) {
-        var offsetX by remember { mutableStateOf(0f) }
-        var offsetY by remember { mutableStateOf(0f) }
+        var offsetX by remember { mutableFloatStateOf(0f) }
+        var offsetY by remember { mutableFloatStateOf(0f) }
 
         Box(
             Modifier
@@ -324,8 +326,8 @@ private fun SwipeableSample() {
 @Composable
 private fun TransformableSample() {
     // set up all transformation states
-    var scale by remember { mutableStateOf(1f) }
-    var rotation by remember { mutableStateOf(0f) }
+    var scale by remember { mutableFloatStateOf(1f) }
+    var rotation by remember { mutableFloatStateOf(0f) }
     var offset by remember { mutableStateOf(Offset.Zero) }
     val state = rememberTransformableState { zoomChange, offsetChange, rotationChange ->
         scale *= zoomChange


### PR DESCRIPTION
The lint tool reported AutoboxingStateCreation warnings in multiple files. Using the generic  for primitive types (Int, Float, Long) can lead to performance overhead due to autoboxing.

This commit resolves these warnings by replacing  with its specialized, more performant counterparts (, , ) where applicable. This change improves performance by avoiding unnecessary object allocations for primitive state values.