### PR TITLE
Build: Increase Gradle JVM heap size to 4g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Mon May 22 14:59:56 BST 2023
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4g
 
 # Turn on parallel compilation, caching and on-demand configuration
 org.gradle.configureondemand=true


### PR DESCRIPTION
Increased the 'org.gradle.jvmargs' from -Xmx2048m to -Xmx4g in 'gradle.properties' to provide more heap space for the Gradle daemon. This helps prevent out-of-memory errors during large builds.