### PR TITLE
Fix typo for Activity constant (CANCELLED -> CANCELED)

### DIFF
--- a/wear/src/main/java/com/example/wear/snippets/complication/ConfigurationActivity.kt
+++ b/wear/src/main/java/com/example/wear/snippets/complication/ConfigurationActivity.kt
@@ -70,7 +70,7 @@ class ConfigurationActivity : ComponentActivity() {
             Spacer(modifier = Modifier.height(4.dp))
             Button(onClick = {
                 // [START android_wear_complication_configuration_finish]
-                setResult(RESULT_OK) // Or RESULT_CANCELLED to cancel configuration
+                setResult(RESULT_OK) // Or RESULT_CANCELED to cancel configuration
                 finish()
                 // [END android_wear_complication_configuration_finish]
             }) {


### PR DESCRIPTION
The constant uses U.S. English spelling:
https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/app/Activity.java;l=777