### PR TITLE
Disabling some "unused" warnings

### DIFF
--- a/misc/src/main/java/com/example/snippets/PreloadManagerKotlinSnippets.kt
+++ b/misc/src/main/java/com/example/snippets/PreloadManagerKotlinSnippets.kt
@@ -30,6 +30,7 @@ import java.lang.Math.abs
 // constants to make the code snippets work
 const val currentPlayingIndex = 10
 
+@Suppress("Unused")
 @UnstableApi
 // [START android_defaultpreloadmanager_MyTargetPreloadStatusControl]
 class MyTargetPreloadStatusControl(
@@ -57,6 +58,7 @@ class MyTargetPreloadStatusControl(
 }
 // [END android_defaultpreloadmanager_MyTargetPreloadStatusControl]
 
+@Suppress("Unused")
 class PreloadManagerSnippetsKotlin {
 
     class PreloadSnippetsActivity : AppCompatActivity() {
@@ -72,8 +74,6 @@ class PreloadManagerSnippetsKotlin {
                 DefaultPreloadManager.Builder(context, targetPreloadStatusControl)
             val preloadManager = preloadManagerBuilder.build()
             // [END android_defaultpreloadmanager_createPLM]
-
-            val player = preloadManagerBuilder.buildExoPlayer()
 
             // [START android_defaultpreloadmanager_addMedia]
             val initialMediaItems = pullMediaItemsFromService(/* count= */ 20)

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
@@ -6,6 +6,7 @@ import android.os.PowerManager;
 
 import androidx.annotation.Nullable;
 
+@SuppressWarnings("Unused")
 public class WakeLockSnippetsJava extends Activity {
 
     PowerManager.WakeLock wakeLock;
@@ -23,6 +24,7 @@ public class WakeLockSnippetsJava extends Activity {
         super.onCreate(savedInstanceState);
     }
 
+    @SuppressWarnings("Unused")
     // [START android_backgroundwork_wakelock_release_java]
     void doSomethingAndRelease() throws MyException {
         try {

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.os.PowerManager
 
 // Snippets for doc page go here
+@Suppress("Unused")
 class WakeLockSnippetsKotlin : Activity() {
 
     // [START android_backgroundwork_wakelock_create_kotlin]


### PR DESCRIPTION
I'd submitted code that's never actually used in the android/snippets apps. Ideally we'd include it in an app, but in the meantime, disabling the "unused" warnings.

Also removed one line (outside of a published-on-DAC code block) that turned out not to be needed.

No changes to the code that's included on DAC, and the code still compiles.