### PR TITLE
Resolve warnings in the Wakelock code snippets

### DIFF
--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsJava.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 public class WakeLockSnippetsJava extends Activity {
 
     PowerManager.WakeLock wakeLock;
+    long wlTimeout = 10*60*1000L; // 10 minutes
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -18,7 +19,7 @@ public class WakeLockSnippetsJava extends Activity {
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         PowerManager.WakeLock wakeLock =
                 powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag");
-        wakeLock.acquire();
+        wakeLock.acquire(wlTimeout);
         // [END android_backgroundwork_wakelock_create_java]
 
         super.onCreate(savedInstanceState);
@@ -28,7 +29,7 @@ public class WakeLockSnippetsJava extends Activity {
     // [START android_backgroundwork_wakelock_release_java]
     void doSomethingAndRelease() throws MyException {
         try {
-            wakeLock.acquire();
+            wakeLock.acquire(wlTimeout);
             doTheWork();
         } finally {
             wakeLock.release();

--- a/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
+++ b/misc/src/main/java/com/example/snippets/backgroundwork/WakeLockSnippetsKotlin.kt
@@ -17,7 +17,6 @@
 package com.example.snippets.backgroundwork
 
 import android.app.Activity
-import android.content.Context
 import android.os.Bundle
 import android.os.PowerManager
 
@@ -25,11 +24,12 @@ import android.os.PowerManager
 @Suppress("unused_parameter")
 class WakeLockSnippetsKotlin : Activity() {
 
+    val wlTimeout = 10*60*1000L // 10 minutes
     // [START android_backgroundwork_wakelock_create_kotlin]
     val wakeLock: PowerManager.WakeLock =
-        (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
+        (getSystemService(POWER_SERVICE) as PowerManager).run {
             newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "MyClassName::MyWakelockTag").apply {
-                acquire()
+                acquire(wlTimeout)
             }
         }
     // [END android_backgroundwork_wakelock_create_kotlin]
@@ -44,7 +44,7 @@ class WakeLockSnippetsKotlin : Activity() {
     fun doSomethingAndRelease() {
         wakeLock.apply {
             try {
-                acquire()
+                acquire(wlTimeout)
                 doTheWork()
             } finally {
                 release()


### PR DESCRIPTION
I was getting code warnings in Android Studio, made some minor changes to resolve them:

* used `WakeLock.acquire(timeout)` instead of `acquire()`
* removed the redundant qualifier for `POWER_SERVICE`

Once this PR is approved, I'll set up a corresponding docs CL to update the description to explain the acquire() parameter.