### PR TITLE
Add incorrectly removed SessionConfigureConfigurationNotSupported

### DIFF
--- a/xr/src/main/java/com/example/xr/arcore/Anchors.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Anchors.kt
@@ -21,6 +21,7 @@ import androidx.xr.arcore.AnchorCreateSuccess
 import androidx.xr.arcore.Trackable
 import androidx.xr.runtime.Config
 import androidx.xr.runtime.Session
+import androidx.xr.runtime.SessionConfigureConfigurationNotSupported
 import androidx.xr.runtime.SessionConfigureSuccess
 import androidx.xr.runtime.math.Pose
 import androidx.xr.scenecore.AnchorEntity
@@ -34,6 +35,8 @@ fun configureAnchoring(session: Session) {
     )
     when (val result = session.configure(newConfig)) {
         is SessionConfigureSuccess -> TODO(/* Success! */)
+        is SessionConfigureConfigurationNotSupported ->
+            TODO(/* Some combinations of configurations are not valid. Handle this failure case. */)
         else ->
             TODO(/* The session could not be configured. See SessionConfigureResult for possible causes. */)
     }

--- a/xr/src/main/java/com/example/xr/arcore/Hands.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Hands.kt
@@ -23,6 +23,7 @@ import androidx.xr.arcore.Hand
 import androidx.xr.arcore.HandJointType
 import androidx.xr.runtime.Config
 import androidx.xr.runtime.Session
+import androidx.xr.runtime.SessionConfigureConfigurationNotSupported
 import androidx.xr.runtime.SessionConfigureSuccess
 import androidx.xr.runtime.math.Pose
 import androidx.xr.runtime.math.Quaternion
@@ -40,6 +41,8 @@ fun ComponentActivity.configureSession(session: Session) {
     )
     when (val result = session.configure(newConfig)) {
         is SessionConfigureSuccess -> TODO(/* Success! */)
+        is SessionConfigureConfigurationNotSupported ->
+            TODO(/* Some combinations of configurations are not valid. Handle this failure case. */)
         else ->
             TODO(/* The session could not be configured. See SessionConfigureResult for possible causes. */)
     }

--- a/xr/src/main/java/com/example/xr/arcore/Planes.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Planes.kt
@@ -19,6 +19,7 @@ package com.example.xr.arcore
 import androidx.xr.arcore.Plane
 import androidx.xr.runtime.Config
 import androidx.xr.runtime.Session
+import androidx.xr.runtime.SessionConfigureConfigurationNotSupported
 import androidx.xr.runtime.SessionConfigureSuccess
 import androidx.xr.runtime.math.Pose
 import androidx.xr.runtime.math.Ray
@@ -31,6 +32,8 @@ fun configurePlaneTracking(session: Session) {
     )
     when (val result = session.configure(newConfig)) {
         is SessionConfigureSuccess -> TODO(/* Success! */)
+        is SessionConfigureConfigurationNotSupported ->
+            TODO(/* Some combinations of configurations are not valid. Handle this failure case. */)
         else ->
             TODO(/* The session could not be configured. See SessionConfigureResult for possible causes. */)
     }


### PR DESCRIPTION
#622 removed `SessionConfigureConfigurationNotSupported`, which was in error. Version `1.0.0-alpha06` still contains `SessionConfigureConfigurationNotSupported`.