### PR TITLE
feat(ai): Add initial Gemini API snippets in Java

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,8 @@ glide = "1.0.0-beta08"
 google-maps = "19.2.0"
 gradle-versions = "0.53.0"
 guava = "33.5.0-jre"
+guava-android = "31.0.1-android"
+reactive-streams = "1.0.4"
 hilt = "2.57.1"
 horologist = "0.8.2-alpha"
 junit = "4.13.2"
@@ -186,6 +188,8 @@ google-android-material = { module = "com.google.android.material:material", ver
 googlemaps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }
 googlemaps-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "google-maps" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+guava-android = { module = "com.google.guava:guava", version.ref = "guava-android" }
+reactive-streams = { module = "org.reactivestreams:reactive-streams", version.ref = "reactive-streams" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 horologist-compose-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }

--- a/misc/build.gradle.kts
+++ b/misc/build.gradle.kts
@@ -82,6 +82,14 @@ dependencies {
     implementation(libs.firebase.ai)
     // [END firebase_ai_bom]
 
+    // Required for one-shot operations (to use `ListenableFuture` from Guava
+    // Android)
+    implementation(libs.guava.android)
+
+    // Required for streaming operations (to use `Publisher` from Reactive
+    // Streams)
+    implementation(libs.reactive.streams)
+
     testImplementation(libs.junit)
     testImplementation(kotlin("test"))
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/misc/src/main/java/com/example/snippets/ai/GenerativeAiSnippetsJava.java
+++ b/misc/src/main/java/com/example/snippets/ai/GenerativeAiSnippetsJava.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.ai;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.firebase.ai.FirebaseAI;
+import com.google.firebase.ai.GenerativeModel;
+import com.google.firebase.ai.java.GenerativeModelFutures;
+import com.google.firebase.ai.type.Content;
+import com.google.firebase.ai.type.GenerateContentResponse;
+import com.google.firebase.ai.type.GenerativeBackend;
+
+import java.util.concurrent.Executor;
+
+final class GenerativeAiSnippetsJava {
+
+    private GenerativeAiSnippetsJava() {}
+
+    static final class GeminiDeveloperApi25FlashModelConfigurationJava {
+        // [START firebase_ai_generative_backend_configuration_java]
+        public static GenerativeModel firebaseAI = FirebaseAI.getInstance(GenerativeBackend.googleAI())
+                .generativeModel("gemini-2.5-flash");
+
+        public static GenerativeModelFutures model = GenerativeModelFutures.from(firebaseAI);
+        // [END firebase_ai_generative_backend_configuration_java]
+
+    }
+    public static void textOnlyInput(Executor executor) {
+        GenerativeModelFutures model = GeminiDeveloperApi25FlashModelConfigurationJava.model;
+        // [START firebase_ai_text_only_input_java]
+        Content prompt = new Content.Builder()
+                .addText("Write a story about a magic backpack.")
+                .build();
+
+        ListenableFuture<GenerateContentResponse> response = model.generateContent(prompt);
+        Futures.addCallback(response, new FutureCallback<GenerateContentResponse>() {
+            @Override
+            public void onSuccess(GenerateContentResponse result) {
+                String resultText = result.getText();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                t.printStackTrace();
+            }
+        }, executor);
+        // [END firebase_ai_text_only_input_java]
+    }
+}


### PR DESCRIPTION
This commit adds the initial Java snippets for the Firebase AI Gemini API.

It includes a snippet demonstrating how to configure a model and another for making a text-only input request.

New dependencies `guava-android` and `reactive-streams` were added to support `ListenableFuture` and `Publisher` for one-shot and streaming operations, respectively.

Region-Tags:
- `firebase_ai_generative_backend_configuration_java`
- `firebase_ai_text_only_input_java`