### PR TITLE
feat(ai): Add multimodal and image generation snippets

### DIFF
--- a/misc/src/main/res/drawable/scones.xml
+++ b/misc/src/main/res/drawable/scones.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2025 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<animated-image xmlns:android="http://schemas.android.com/apk/res/android">
+
+</animated-image>


### PR DESCRIPTION
This commit adds several new snippets for the Firebase AI SDK, demonstrating multimodal capabilities and image generation.

New snippets include:
- Text and image input
- Text and audio input
- Text and video input
- Multi-turn chat
- Image generation from a text prompt
- Image editing with a text prompt
- Image editing in a chat session

A placeholder drawable `scones.xml` is also added to support the image editing snippets.