### PR TITLE
Add closing curly brackets to navigation

### DIFF
--- a/wear/src/main/java/com/example/wear/snippets/m3/navigation/Navigation.kt
+++ b/wear/src/main/java/com/example/wear/snippets/m3/navigation/Navigation.kt
@@ -74,7 +74,7 @@ fun MessageDetail(id: String) {
         contentPadding = padding
     ) { scaffoldPaddingValues ->
         // Screen content goes here
-        // [END android_wear_navigation]
+        // [START_EXCLUDE]
         TransformingLazyColumn(
             state = scrollState,
             contentPadding = scaffoldPaddingValues
@@ -87,6 +87,8 @@ fun MessageDetail(id: String) {
                 )
             }
         }
+        // [END_EXCLUDE]
+        // [END android_wear_navigation]
     }
 }
 


### PR DESCRIPTION
Currently the snippet for navigation doesn't include closing curly brackets for brevity but seems wrong. So i moved the end of the snippet a bit down and excluded the part that is not relevant for navigation