### PR TITLE
Resolve ambiguity for Color with named imports

### DIFF
--- a/misc/src/main/java/com/example/snippets/ai/ImagenSnippets.kt
+++ b/misc/src/main/java/com/example/snippets/ai/ImagenSnippets.kt
@@ -57,8 +57,8 @@ import com.google.firebase.ai.type.ImagenAspectRatio
 import com.google.firebase.ai.type.ImagenBackgroundMask
 import com.google.firebase.ai.type.ImagenControlReference
 import com.google.firebase.ai.type.ImagenControlType
-import com.google.firebase.ai.type.ImagenEditingConfig
 import com.google.firebase.ai.type.ImagenEditMode
+import com.google.firebase.ai.type.ImagenEditingConfig
 import com.google.firebase.ai.type.ImagenGenerationConfig
 import com.google.firebase.ai.type.ImagenGenerationResponse
 import com.google.firebase.ai.type.ImagenImageFormat
@@ -170,6 +170,8 @@ suspend fun removeBallFromImage(
 // [END android_imagen_inpaint_removal]
 
 // [START android_imagen_editing_mask_editor]
+//import androidx.compose.ui.graphics.Color as ComposeColor
+
 @Composable
 fun ImagenEditingMaskEditor(
     sourceBitmap: Bitmap,
@@ -260,6 +262,9 @@ fun ImagenEditingMaskEditor(
 // [END android_imagen_editing_mask_editor]
 
 // [START android_imagen_editing_create_mask]
+// import android.graphics.Color as AndroidColor
+// import android.graphics.Paint
+
 private fun createMaskBitmap(
     sourceBitmap: Bitmap,
     paths: SnapshotStateList<Path>,


### PR DESCRIPTION
Resolves an import ambiguity by specifying `ComposeColor` and `AndroidColor` type aliases in the Imagen snippets. This change also cleans up unused imports and alphabetizes the remaining ones.

These snippets use multiple "Color" classes so we need named imports to distinguish them. Here is the current documentation. I can't put region tags around the imports because Android Studio and Spotless will reorder the comments and break the inclusion regions. I think a comment is a reasonable solution to show the imports.

<img width="700" height="162" alt="Screenshot 2025-10-23 at 11 59 30 AM" src="https://github.com/user-attachments/assets/977a9a92-690f-464a-91ab-6d0227da4ddd" />
<img width="713" height="92" alt="Screenshot 2025-10-23 at 11 59 36 AM" src="https://github.com/user-attachments/assets/b4cc807e-c212-4957-983d-f893b7831f76" />

Documentation page:
* https://developer.android.com/ai/imagen