### PR TITLE
Fix bug in usage of END_EXCLUDE

### DIFF
--- a/datastore/src/main/java/com/example/datastore/snippets/TimestampUpdateService.kt
+++ b/datastore/src/main/java/com/example/datastore/snippets/TimestampUpdateService.kt
@@ -34,7 +34,7 @@ class TimestampUpdateService : Service() {
 
     // [START_EXCLUDE silent]
     override fun onBind(intent: Intent): IBinder? = null
-    // [END_EXCLUDE silent]
+    // [END_EXCLUDE]
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         serviceScope.launch {


### PR DESCRIPTION
We use a [START_EXCLUDE silent] tag to exclude code from snippets. This exclude block should end with an
[END_EXCLUDE] tag, instead of [END_EXCLUDE silent]. 