### PR TITLE
chore: adds adaptive team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# Code owners file.
-# This file controls who is tagged for review for any given pull request.
-#
-# For syntax help see:
-# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
-
-
-/compose/snippets/src/main/java/com/example/compose/snippets/adaptivelayouts/                             @android/adr-adaptive

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,4 @@
 /wear/          @android/devrel-wear
 /wearcompanion/ @android/devrel-wear
 /xr/            @android/devrel-xr
+/compose/snippets/src/main/java/com/example/compose/snippets/adaptivelayouts/ @android/devrel-adaptive-apps


### PR DESCRIPTION
This PR adds the ADR Adaptive team as the CODEOWNERS under `compose/snippets/src/main/java/com/example/compose/snippets/adaptivelayouts`. 

**Important**: Before this PR can be merged, a GitHub team for the Adaptive group must be created. 