### PR TITLE
Add snippet for enabling diagnostic stack traces

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/performance/Stacktraces.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/performance/Stacktraces.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composer
 import androidx.compose.runtime.tooling.ComposeStackTraceMode
 
 // [START android_compose_stacktraces_enable]
+// Enable stack traces at application level: onCreate
 class SampleStackTracesEnabledApp : Application() {
 
     override fun onCreate() {


### PR DESCRIPTION
Demo how to enable diagnostic stack traces in Jetpack Compose for improved debugging. 

Note: You need Kotlin 2.3 and R8 enabled to make `GroupKeys` option work