### PR TITLE
Add information on accessing the underlying mobile runtime

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-xr-compose = "1.0.0-alpha08"
 androidx-xr-scenecore = "1.0.0-alpha08"
 androidxHiltNavigationCompose = "1.3.0"
 appcompat = "1.7.1"
+arcorePlayServices = "1.0.0-alpha08"
 coil = "2.7.0"
 # @keep
 compileSdk = "36"
@@ -47,6 +48,7 @@ datastorePreferencesRxjava2 = "1.1.7"
 datastorePreferencesRxjava3 = "1.1.7"
 firebase-bom = "34.4.0"
 glide = "1.0.0-beta08"
+google-ar-core = "1.51.0"
 google-maps = "19.2.0"
 gradle-versions = "0.53.0"
 guava = "33.5.0-jre"
@@ -104,6 +106,7 @@ android-identity-googleid = { module = "com.google.android.libraries.identity.go
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-arcore-play-services = { module = "androidx.xr.arcore:arcore-play-services", version.ref = "arcorePlayServices" }
 androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose-latest" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose-latest" }
@@ -202,6 +205,7 @@ firebase-ai = { module = "com.google.firebase:firebase-ai" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 glide-compose = { module = "com.github.bumptech.glide:compose", version.ref = "glide" }
 google-android-material = { module = "com.google.android.material:material", version.ref = "material" }
+google-ar-core = { module = "com.google.ar:core", version.ref = "google-ar-core" }
 google-protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }
 googlemaps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "maps-compose" }
 googlemaps-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "google-maps" }

--- a/xr/build.gradle.kts
+++ b/xr/build.gradle.kts
@@ -32,6 +32,8 @@ android {
 
 dependencies {
     implementation(libs.androidx.xr.arcore)
+    implementation(libs.androidx.arcore.play.services)
+    implementation(libs.google.ar.core)
     implementation(libs.androidx.xr.scenecore)
     implementation(libs.androidx.xr.compose)
 

--- a/xr/src/main/java/com/example/xr/arcore/Mobile.kt
+++ b/xr/src/main/java/com/example/xr/arcore/Mobile.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.xr.arcore
+
+import androidx.xr.arcore.playservices.ArCoreRuntime
+import androidx.xr.arcore.playservices.UnsupportedArCoreCompatApi
+import androidx.xr.runtime.Session
+
+@OptIn(UnsupportedArCoreCompatApi::class)
+fun accessMobileRuntime(session: Session) {
+    // [START androidxr_arcore_mobile_runtime]
+    val arCoreRuntime = session.runtimes.firstNotNullOfOrNull { it as? ArCoreRuntime } ?: return
+    val originalSession = arCoreRuntime.lifecycleManager.session()
+    val originalFrame = arCoreRuntime.perceptionManager.lastFrame()
+    // [END androidxr_arcore_mobile_runtime]
+}


### PR DESCRIPTION
Adds dependencies and an example on how to access an underlying ARCore mobile runtime on ARCore for Jetpack XR.