### PR TITLE
Fix code to show imports in Wear migration guidance

### DIFF
--- a/wear/src/main/java/com/example/wear/snippets/m3/theme/Color.kt
+++ b/wear/src/main/java/com/example/wear/snippets/m3/theme/Color.kt
@@ -18,9 +18,20 @@ package com.example.wear.snippets.m3.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+// [START android_wear_color]
 import androidx.wear.compose.material3.ColorScheme
+// [START_EXCLUDE]
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.dynamicColorScheme
+
+
+fun color() {
+// [END_EXCLUDE]
+    val appColorScheme: ColorScheme = ColorScheme(
+        // M3 ColorScheme parameters
+    )
+    // [END android_wear_color]
+}
 
 // [START android_wear_dynamic_theme]
 @Composable
@@ -30,12 +41,4 @@ fun myApp() {
 }
 
 internal val myBrandColors: ColorScheme = ColorScheme( /* Specify colors here */)
-// [END android_wear_dynamic_theme]]
-
-fun color() {
-    // [START android_wear_color]
-    val appColorScheme: ColorScheme = ColorScheme(
-        // M3 ColorScheme parameters
-    )
-    // [END android_wear_color]
-}
+// [END android_wear_dynamic_theme]

--- a/wear/src/main/java/com/example/wear/snippets/m3/theme/Shape.kt
+++ b/wear/src/main/java/com/example/wear/snippets/m3/theme/Shape.kt
@@ -15,10 +15,9 @@
  */
 
 package com.example.wear.snippets.m3.theme
-
+// [START android_wear_shape]
 import androidx.wear.compose.material3.Shapes
 
-// [START android_wear_shape]
 val Shapes = Shapes(
     // M3 Shapes parameters
 )

--- a/wear/src/main/java/com/example/wear/snippets/m3/theme/Theme.kt
+++ b/wear/src/main/java/com/example/wear/snippets/m3/theme/Theme.kt
@@ -18,23 +18,21 @@ package com.example.wear.snippets.m3.theme
 
 import androidx.compose.runtime.Composable
 import androidx.wear.compose.material3.ColorScheme
+// [START android_wear_material_theme]
 import androidx.wear.compose.material3.MaterialTheme
+// [START_EXCLUDE]
 import androidx.wear.compose.material3.MotionScheme
 import androidx.wear.compose.material3.Shapes
 import androidx.wear.compose.material3.Typography
 
 @Composable
 fun materialTheme() {
-    val appColorScheme = ColorScheme()
-    val appTypography = Typography()
-    val appShapes = Shapes()
-    val appMotionScheme = MotionScheme.standard()
-    // [START android_wear_material_theme]
+    // [END_EXCLUDE]
     MaterialTheme(
-        colorScheme = appColorScheme,
-        typography = appTypography,
-        shapes = appShapes,
-        motionScheme = appMotionScheme,
+        colorScheme = ColorScheme(),
+        typography = Typography(),
+        shapes = Shapes(),
+        motionScheme = MotionScheme.standard(),
         content = { /*content here*/ }
     )
     // [END android_wear_material_theme]

--- a/wear/src/main/java/com/example/wear/snippets/m3/theme/Typography.kt
+++ b/wear/src/main/java/com/example/wear/snippets/m3/theme/Typography.kt
@@ -15,10 +15,9 @@
  */
 
 package com.example.wear.snippets.m3.theme
-
+// [START android_wear_typography]
 import androidx.wear.compose.material3.Typography
 
-// [START android_wear_typography]
 val Typography = Typography(
     // M3 TextStyle parameters
 )


### PR DESCRIPTION
Readd imports that were lost in previous PRs to show the imports that are useful in the Wear M3 migration guidance.