### PR TITLE
Read AndroidX Snapshot ID from gradle.properties instead of env

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,7 @@ kotlin.code.style=official
 
 # Enable R8 full mode.
 android.enableR8.fullMode=true
+
+# Use an AndroidX snapshot build.
+# https://androidx.dev/snapshots/builds
+# snapshotVersion=14793336

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-val snapshotVersion: String? = System.getenv("COMPOSE_SNAPSHOT_ID")
+val snapshotVersion: String? by settings
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
Hey,
I'd like to propose reading the AndroidX snapshot ID from `settings.gradle.kts` instead of from the system environment variables. If you switch to snapshot libraries, you need to update `libs.versions.toml` to switch to `-SNAPSHOT` version specifications. That means you should have also checked in the fact that you are swapping to a snapshot repository, which is not possible when reading from System environment variables.

I had an internal and external check for usages of COMPOSE_SNAPSHOT_ID, but couldn't find any.