### PR TITLE
Fix CircularProgressIndicator size in snippets

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/ProgressIndicator.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -132,7 +132,7 @@ fun CircularDeterminateIndicator() {
         if (loading) {
             CircularProgressIndicator(
                 progress = { currentProgress },
-                modifier = Modifier.width(64.dp),
+                modifier = Modifier.size(64.dp),
             )
         }
     }
@@ -169,7 +169,7 @@ fun IndeterminateCircularIndicator() {
     if (!loading) return
 
     CircularProgressIndicator(
-        modifier = Modifier.width(64.dp),
+        modifier = Modifier.size(64.dp),
         color = MaterialTheme.colorScheme.secondary,
         trackColor = MaterialTheme.colorScheme.surfaceVariant,
     )


### PR DESCRIPTION
**width** replaced with **size**, because using **width** causes the component to jitter during layout updates

Before
![before](https://github.com/user-attachments/assets/0317c17f-e8b9-4c3d-8924-96633bbf5ce5)

After
![after](https://github.com/user-attachments/assets/c127d733-7856-4984-bdd1-b8a766755fe1)

