### PR TITLE
Expand the scope of a snippet

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/layouts/UiMediaQuery.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/layouts/UiMediaQuery.kt
@@ -71,22 +71,28 @@ class MyApplication : Application() {
 // [END android_compose_layout_mediaQuery_enable_mediaQuery]
 
 @Preview(showBackground = true)
+// [START android_compose_layout_mediaQuery_use_mediaQuery]
 @Composable
-fun MediaQueryUsage(
+fun VideoPlayer(
+    // [START_EXCLUDE]
     @PreviewParameter(PostureProvider::class) posture: Posture
+    // [END_EXCLUDE]
 ) {
+    // [START_EXCLUDE]
     EnableMediaQueryIntegration {
         OverrideUiMediaScope(windowPosture = posture.value) {
-            // [START android_compose_layout_mediaQuery_use_mediaQuery]
+    // [END_EXCLUDE]
             if (mediaQuery { windowPosture == UiMediaScope.Posture.Tabletop }) {
                 TabletopLayout()
             } else {
                 FlatLayout()
             }
-            // [END android_compose_layout_mediaQuery_use_mediaQuery]
+    // [START_EXCLUDE]
         }
     }
+    // [END_EXCLUDE]
 }
+// [END android_compose_layout_mediaQuery_use_mediaQuery]
 
 @Preview(showBackground = true, widthDp = 480, heightDp = 320, name = "Compact")
 @Preview(showBackground = true, widthDp = 600, heightDp = 320, name = "Medium")

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,4 +32,4 @@ android.enableR8.fullMode=true
 android.newDsl=false
 # Use an AndroidX snapshot build.
 # https://androidx.dev/snapshots/builds
-snapshotVersion=14930909
+# snapshotVersion=14930909


### PR DESCRIPTION
- Expand the scope of a snippet to include the name of a custom composable.
- Remove the snapshot version as UiMediaQuery is shipped as a Compose 1.11.0-beta01.