### PR TITLE
Fix silent END_EXCLUDE tag

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/accessibility/ScalableContentSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/accessibility/ScalableContentSnippets.kt
@@ -76,7 +76,7 @@ private class DensityScalingState(
 
 // [START_EXCLUDE silent]
 @Preview
-// [END_EXCLUDE silent]
+// [END_EXCLUDE]
 @Composable
 fun DensityScalingSample() {
     val currentDensity = LocalDensity.current
@@ -120,7 +120,7 @@ class FontScaleState(
 
 // [START_EXCLUDE silent]
 @Preview
-// [END_EXCLUDE silent]
+// [END_EXCLUDE]
 @Composable
 fun FontScalingSample() {
     val currentDensity = LocalDensity.current


### PR DESCRIPTION
DensityScalingSample function is not showing up in this code snippet on the documentation page: https://developer.android.com/develop/ui/compose/accessibility/scalable-content#density-scaling

The closing exclude tag should be [END_EXCLUDE] and not [END_EXCLUDE silent]