### PR TITLE
Fix: Replace `[END_EXCLUDE silent]` with `[END_EXCLUDE]`

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/accessibility/ScalableContentSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/accessibility/ScalableContentSnippets.kt
@@ -76,7 +76,7 @@ private class DensityScalingState(
 
 // [START_EXCLUDE silent]
 @Preview
-// [END_EXCLUDE silent]
+// [END_EXCLUDE]
 @Composable
 fun DensityScalingSample() {
     val currentDensity = LocalDensity.current
@@ -120,7 +120,7 @@ class FontScaleState(
 
 // [START_EXCLUDE silent]
 @Preview
-// [END_EXCLUDE silent]
+// [END_EXCLUDE]
 @Composable
 fun FontScalingSample() {
     val currentDensity = LocalDensity.current

--- a/compose/snippets/src/main/java/com/example/compose/snippets/interop/InteroperabilityAPIsSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/interop/InteroperabilityAPIsSnippets.kt
@@ -257,7 +257,7 @@ class MyView(context: Context) : View(context) {
 
     fun clear() { }
 }
-// [END_EXCLUDE silent]
+// [END_EXCLUDE]
 // [END android_compose_interop_apis_views_in_compose]
 
 // [START android_compose_interop_apis_android_view_binding]

--- a/misc/src/main/java/com/example/snippets/profiling/ProfilingManagerJavaSnippets.java
+++ b/misc/src/main/java/com/example/snippets/profiling/ProfilingManagerJavaSnippets.java
@@ -132,7 +132,7 @@ public class ProfilingManagerJavaSnippets {
         // This will cause the TRIGGER_TYPE_APP_FULLY_DRAWN to be emitted.
         reportFullyDrawn();
       });
-      // [END_EXCLUDE silent]
+      // [END_EXCLUDE]
     }
     // [END android_profiling_manager_triggered_trace_java]
 
@@ -203,7 +203,7 @@ public class ProfilingManagerJavaSnippets {
       while (System.currentTimeMillis() - start < durationMs) {
       }
     }
-    // [END_EXCLUDE silent]
+    // [END_EXCLUDE]
 
     void prepareNetworkRequest() {
       // [START_EXCLUDE]

--- a/misc/src/main/java/com/example/snippets/profiling/ProfilingManagerKotlinSnippets.kt
+++ b/misc/src/main/java/com/example/snippets/profiling/ProfilingManagerKotlinSnippets.kt
@@ -135,7 +135,7 @@ class ProfilingManagerKotlinSnippets {
                 // This will cause the TRIGGER_TYPE_APP_FULLY_DRAWN to be emitted.
                 reportFullyDrawn()
             }
-            // [END_EXCLUDE silent]
+            // [END_EXCLUDE]
         }
         // [END android_profiling_manager_triggered_trace]
 


### PR DESCRIPTION
This pull request addresses the request to fix instances of `[END_EXCLUDE silent]` across the codebase, replacing them with the standard `[END_EXCLUDE]` tag. This primarily affects code snippet extraction markers.

Files modified:
- `compose/snippets/src/main/java/com/example/compose/snippets/accessibility/ScalableContentSnippets.kt`
- `compose/snippets/src/main/java/com/example/compose/snippets/interop/InteroperabilityAPIsSnippets.kt`
- `misc/src/main/java/com/example/snippets/profiling/ProfilingManagerKotlinSnippets.kt`
- `misc/src/main/java/com/example/snippets/profiling/ProfilingManagerJavaSnippets.java`

Code snippets are for:
- Standardizing snippet inclusion syntax across documentation blocks.

---
*PR created automatically by Jules for task [13753915747602979855](https://jules.google.com/task/13753915747602979855) started by @kkuan2011*