### PR TITLE
Separate XR version catalog from the main catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,12 +36,6 @@ androidx-window = "1.5.1"
 androidx-window-core = "1.5.1"
 androidx-window-java = "1.5.1"
 androidx-work-runtime = "2.11.1"
-androidx-xr-arcore = "1.0.0-alpha13"
-androidx-xr-arcore-play-services = "1.0.0-alpha13"
-androidx-xr-compose = "1.0.0-alpha13"
-androidx-xr-glimmer = "1.0.0-alpha12"
-androidx-xr-projected = "1.0.0-alpha07"
-androidx-xr-scenecore = "1.0.0-alpha14"
 androidxHiltNavigationCompose = "1.3.0"
 appcompat = "1.7.1"
 coil = "2.7.0"
@@ -240,13 +234,6 @@ androidx-window-core = { module = "androidx.window:window-core", version.ref = "
 androidx-window-java = { module = "androidx.window:window-java", version.ref = "androidx-window-java" }
 androidx-work-runtime = { module = "androidx.work:work-runtime", version.ref = "androidx-work-runtime" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidx-work-runtime" }
-androidx-xr-arcore = { module = "androidx.xr.arcore:arcore", version.ref = "androidx-xr-arcore" }
-androidx-xr-arcore-play-services = { module = "androidx.xr.arcore:arcore-play-services", version.ref = "androidx-xr-arcore-play-services" }
-androidx-xr-compose = { module = "androidx.xr.compose:compose", version.ref = "androidx-xr-compose" }
-androidx-xr-glimmer = { module = "androidx.xr.glimmer:glimmer", version.ref = "androidx-xr-glimmer" }
-androidx-xr-projected = { module = "androidx.xr.projected:projected", version.ref = "androidx-xr-projected" }
-androidx-xr-projected-testing = { module = "androidx.xr.projected:projected-testing", version.ref = "androidx-xr-projected" }
-androidx-xr-scenecore = { module = "androidx.xr.scenecore:scenecore", version.ref = "androidx-xr-scenecore" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 billing = { module = "com.android.billingclient:billing", version.ref = "playbilling" }
 coil-kt-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,11 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
     }
+    versionCatalogs {
+        create("xrLibs") {
+            from(files("xr/libs.versions.toml"))
+        }
+    }
 }
 rootProject.name = "snippets"
 include(

--- a/xr/build.gradle.kts
+++ b/xr/build.gradle.kts
@@ -44,15 +44,15 @@ val isUsingSnapshot = snapshotVersion != null
 
 
 val implementationXrLibraries = listOf<Provider<MinimalExternalModuleDependency>>(
-    libs.androidx.xr.arcore.asProvider(),
-    libs.androidx.xr.arcore.play.services,
-    libs.androidx.xr.glimmer,
-    libs.androidx.xr.projected.asProvider(),
-    libs.androidx.xr.scenecore,
-    libs.androidx.xr.compose,
+    xrLibs.androidx.xr.arcore.asProvider(),
+    xrLibs.androidx.xr.arcore.play.services,
+    xrLibs.androidx.xr.glimmer,
+    xrLibs.androidx.xr.projected.asProvider(),
+    xrLibs.androidx.xr.scenecore,
+    xrLibs.androidx.xr.compose,
 )
 val testImplementationXrLibraries = listOf<Provider<MinimalExternalModuleDependency>>(
-    libs.androidx.xr.projected.testing,
+    xrLibs.androidx.xr.projected.testing,
 )
 
 dependencies {

--- a/xr/libs.versions.toml
+++ b/xr/libs.versions.toml
@@ -1,0 +1,16 @@
+[versions]
+androidx-xr-arcore = "1.0.0-alpha13"
+androidx-xr-arcore-play-services = "1.0.0-alpha13"
+androidx-xr-compose = "1.0.0-alpha13"
+androidx-xr-glimmer = "1.0.0-alpha12"
+androidx-xr-projected = "1.0.0-alpha07"
+androidx-xr-scenecore = "1.0.0-alpha14"
+
+[libraries]
+androidx-xr-arcore = { module = "androidx.xr.arcore:arcore", version.ref = "androidx-xr-arcore" }
+androidx-xr-arcore-play-services = { module = "androidx.xr.arcore:arcore-play-services", version.ref = "androidx-xr-arcore-play-services" }
+androidx-xr-compose = { module = "androidx.xr.compose:compose", version.ref = "androidx-xr-compose" }
+androidx-xr-glimmer = { module = "androidx.xr.glimmer:glimmer", version.ref = "androidx-xr-glimmer" }
+androidx-xr-projected = { module = "androidx.xr.projected:projected", version.ref = "androidx-xr-projected" }
+androidx-xr-projected-testing = { module = "androidx.xr.projected:projected-testing", version.ref = "androidx-xr-projected" }
+androidx-xr-scenecore = { module = "androidx.xr.scenecore:scenecore", version.ref = "androidx-xr-scenecore" }


### PR DESCRIPTION
Since we expect to update the XR library versions quite often, this PR proposes to pull out the XR libraries to a file located under the XR CODEOWNERS. This helps us land releases on time since `libs.versions.toml` is the only file outside of XR's ownership we're updating. See e.g. #890, #848, #786, #784, etc.