### PR TITLE
Add snippets for Engage SDK Skill

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,6 +112,7 @@ wfp = "1.0.0-rc01"
 androidx-core-telecom = "1.1.0-alpha04"
 media3Session = "1.10.0"
 playServicesFitness = "21.3.0"
+engageCore = "1.5.12"
 
 [libraries]
 accompanist-adaptive = "com.google.accompanist:accompanist-adaptive:0.37.3"
@@ -284,6 +285,7 @@ wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", v
 androidx-core-telecom = { group = "androidx.core", name = "core-telecom", version.ref = "androidx-core-telecom" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "media3Session" }
 play-services-fitness = { group = "com.google.android.gms", name = "play-services-fitness", version.ref = "playServicesFitness" }
+engage-core = { group = "com.google.android.engage", name = "engage-core", version.ref = "engageCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }

--- a/misc/build.gradle.kts
+++ b/misc/build.gradle.kts
@@ -83,6 +83,9 @@ dependencies {
     implementation(libs.firebase.ai)
     implementation(libs.guava.android)
     implementation(libs.reactive.streams)
+
+    implementation(libs.engage.core)
+
     testImplementation(libs.junit)
     testImplementation(kotlin("test"))
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/misc/src/main/AndroidManifest.xml
+++ b/misc/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <permission android:name="com.example.snippets.CUSTOM_PERMISSION"/>
+    <!--[START android_engage_tv_permission]-->
+    <!-- Mandatory for TV integrations -->
+    <uses-permission android:name="com.android.providers.tv.permission.WRITE_EPG_DATA" />
+    <!--[END android_engage_tv_permission]-->
 
     <!--[START android_broadcast_receiver_10_manifest_permission]-->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -72,6 +76,22 @@
               android:name="com.example.snippets.ActivityEmbeddingJavaSnippets.SplitInitializer"
               android:value="androidx.startup" />
         </provider>
+<!--    [START android_engage_broadcast_receiver_static]-->
+        <!--    Add the `<receiver>` tag inside the `<application>` block in `AndroidManifest.xml`:-->
+        <receiver
+            android:name="com.example.snippets.engage.EngageBroadcastReceiver"
+            android:permission="com.google.android.engage.REQUEST_ENGAGE_DATA"
+            android:exported="true"
+            android:enabled="true">
+            <!-- Recommended for production TV APKs -->
+            <intent-filter>
+                <action android:name="com.google.android.engage.action.PUBLISH_RECOMMENDATION" />
+                <action android:name="com.google.android.engage.action.PUBLISH_FEATURED" />
+                <action android:name="com.google.android.engage.action.PUBLISH_CONTINUATION" />
+                <!-- Note: Add vertical-specific intents here if applicable (e.g., FOOD shopping cart, etc.) -->
+            </intent-filter>
+        </receiver>
+<!--    [END android_engage_broadcast_receiver_static]-->
     </application>
 
 </manifest>

--- a/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
@@ -86,7 +86,7 @@ val platformSpecificPlaybackUris = listOf(
         .setActionUri(Uri.parse("https://www.example.com/mobile/play/123"))
         .build()
 )
-// [START android_engage_platform_specific_playback_uris]
+// [END android_engage_platform_specific_playback_uris]
 
 // [START android_engage_account_profile_example]
 val accountProfile = com.google.android.engage.common.datamodel.AccountProfile.Builder()

--- a/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 import android.annotation.SuppressLint
@@ -12,7 +28,7 @@ class AppData {
 }
 
 class AppDataRepository {
-    fun getRecommendations() : List<AppData> {
+    fun getRecommendations(): List<AppData> {
         return emptyList()
     }
 }
@@ -39,7 +55,6 @@ class ClusterRequestFactory(context: Context) {
             .setActionText(signInCardAction)
             .setActionUri(Uri.parse("https://xyz.com/signin"))
             .build()
-
 
     fun constructRecommendationClustersRequest(): com.google.android.engage.service.PublishRecommendationClustersRequest {
 

--- a/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
@@ -20,6 +20,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import com.example.snippets.R
+import com.google.android.engage.common.datamodel.AccountProfile
+import java.util.Locale
 
 class AppData {
     // Example data class using in the app like Post, Movie, Music etc.
@@ -89,9 +91,11 @@ val platformSpecificPlaybackUris = listOf(
 // [END android_engage_platform_specific_playback_uris]
 
 // [START android_engage_account_profile_example]
-val accountProfile = com.google.android.engage.common.datamodel.AccountProfile.Builder()
-    .setAccountId("user_123")
-    .setProfileId("profile_456")
-    .setLocale("en-US")
-    .build()
+val accountProfile: AccountProfile
+    get() = AccountProfile.Builder()
+        .setAccountId("user_123")
+        .setProfileId("profile_456")
+        // AppCompatDelegate.getApplicationLocales().get(0) for Per-App Language Preferences
+        .setLocale(Locale.getDefault().toLanguageTag())
+        .build()
 // [END android_engage_account_profile_example]

--- a/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ClusterRequestFactory.kt
@@ -1,0 +1,82 @@
+package com.example.snippets.engage
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.Uri
+import com.example.snippets.R
+
+class AppData {
+    // Example data class using in the app like Post, Movie, Music etc.
+    val title: String = "title"
+    val author: String = "author"
+}
+
+class AppDataRepository {
+    fun getRecommendations() : List<AppData> {
+        return emptyList()
+    }
+}
+
+@SuppressLint("UseKtx")
+@SuppressWarnings("unused")
+// [START android_engage_cluster_request_factory_implementation]
+class ClusterRequestFactory(context: Context) {
+
+    // [START_EXCLUDE]
+    private val signInCardAction = context.resources.getString(R.string.sign_in_card_action_text)
+    private val appDataRepository = AppDataRepository()
+    // [END_EXCLUDE]
+
+    private val signInCard =
+        com.google.android.engage.common.datamodel.SignInCardEntity.Builder()
+            .addPosterImage(
+                com.google.android.engage.common.datamodel.Image.Builder()
+                    .setImageUri(Uri.parse("http://www.x.com/image.png"))
+                    .setImageHeightInPixel(500)
+                    .setImageWidthInPixel(500)
+                    .build()
+            )
+            .setActionText(signInCardAction)
+            .setActionUri(Uri.parse("https://xyz.com/signin"))
+            .build()
+
+
+    fun constructRecommendationClustersRequest(): com.google.android.engage.service.PublishRecommendationClustersRequest {
+
+        val items = appDataRepository.getRecommendations()
+        val recommendationCluster = com.google.android.engage.common.datamodel.RecommendationCluster.Builder()
+        for (item in items) {
+            recommendationCluster.addEntity(ItemToEntityConverter.convert(item))
+        }
+        return com.google.android.engage.service.PublishRecommendationClustersRequest.Builder()
+            .addRecommendationCluster(recommendationCluster.build())
+            .build()
+    }
+
+    fun constructUserAccountManagementClusterRequest(): com.google.android.engage.service.PublishUserAccountManagementRequest =
+        com.google.android.engage.service.PublishUserAccountManagementRequest.Builder()
+            .setSignInCardEntity(signInCard)
+            .build()
+}
+// [END android_engage_cluster_request_factory_implementation]
+
+// [START android_engage_platform_specific_playback_uris]
+val platformSpecificPlaybackUris = listOf(
+    com.google.android.engage.common.datamodel.PlatformSpecificUri.Builder()
+        .setPlatformType(com.google.android.engage.common.datamodel.PlatformType.TYPE_ANDROID_TV)
+        .setActionUri(Uri.parse("https://www.example.com/tv/play/123"))
+        .build(),
+    com.google.android.engage.common.datamodel.PlatformSpecificUri.Builder()
+        .setPlatformType(com.google.android.engage.common.datamodel.PlatformType.TYPE_ANDROID_MOBILE)
+        .setActionUri(Uri.parse("https://www.example.com/mobile/play/123"))
+        .build()
+)
+// [START android_engage_platform_specific_playback_uris]
+
+// [START android_engage_account_profile_example]
+val accountProfile = com.google.android.engage.common.datamodel.AccountProfile.Builder()
+    .setAccountId("user_123")
+    .setProfileId("profile_456")
+    .setLocale("en-US")
+    .build()
+// [END android_engage_account_profile_example]

--- a/misc/src/main/java/com/example/snippets/engage/Constants.kt
+++ b/misc/src/main/java/com/example/snippets/engage/Constants.kt
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 @SuppressWarnings("unused")
 // [START android_engage_constants_implementation]
 object Constants {
-    //Holds common values like attempt counts, publish types etc.
+    // Holds common values like attempt counts, publish types etc.
     const val REPEAT_INTERVAL = 24L
     const val MAX_PUBLISHING_ATTEMPTS = 3
     const val PUBLISH_TYPE_KEY = "PUBLISH_TYPE"

--- a/misc/src/main/java/com/example/snippets/engage/Constants.kt
+++ b/misc/src/main/java/com/example/snippets/engage/Constants.kt
@@ -1,0 +1,20 @@
+package com.example.snippets.engage
+
+@SuppressWarnings("unused")
+// [START android_engage_constants_implementation]
+object Constants {
+    //Holds common values like attempt counts, publish types etc.
+    const val REPEAT_INTERVAL = 24L
+    const val MAX_PUBLISHING_ATTEMPTS = 3
+    const val PUBLISH_TYPE_KEY = "PUBLISH_TYPE"
+    const val PUBLISH_TYPE_RECOMMENDATIONS = "RECOMMENDATIONS"
+    const val PUBLISH_TYPE_FEATURED = "FEATURED"
+    // const val PUBLISH_TYPE_CONTINUATION = "CONTINUATION"
+    // ...
+    const val PUBLISH_TYPE_USER_ACCOUNT_MANAGEMENT = "USER_ACCOUNT_MANAGEMENT"
+    // const val PUBLISH_TYPE_FOOD_SHOPPING_CARD = "FOOD_SHOPPING_CARD"
+    // const val PUBLISH_TYPE_RESERVATION = "RESERVATION"
+}
+// [END android_engage_constants_implementation]
+
+const val TAG: String = "EngageSDK"

--- a/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 // [START android_engage_broadcast_receiver_implementation]
@@ -18,17 +34,17 @@ class EngageBroadcastReceiver : BroadcastReceiver() {
         if (intent == null || context == null) return
         when (intent.action) {
             com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION
-                -> EngagePublisher.publishOneTime(context,Constants.PUBLISH_TYPE_RECOMMENDATIONS)
+            -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_RECOMMENDATIONS)
             // Note: If app handles other publish actions (e.g. Featured, Continuation), add them here.
             com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED
-                -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FEATURED)
+            -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FEATURED)
 
             /** Note: If vertical has other intents (e.g. FOOD shopping cart, etc.), add them here.
              * com.google.android.engage.food.service.Intents.ACTION_PUBLISH_FOOD_SHOPPING_CART
              * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FOOD_SHOPPING_CARD)
              * com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_RESERVATION
              * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_RESERVATION )
-            **/
+             **/
         }
     }
 

--- a/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
@@ -58,31 +58,16 @@ class EngageBroadcastReceiver : BroadcastReceiver() {
             val appContext = context.applicationContext
             val receiver = EngageBroadcastReceiver()
 
-            // Register Recommendation Cluster Publish Intent
+            // Register Cluster Publish Intents
+            val filter = IntentFilter().apply {
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION)
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED)
+                addAction(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION)
+            }
             ContextCompat.registerReceiver(
                 appContext,
                 receiver,
-                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
-                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
-                null,
-                ContextCompat.RECEIVER_EXPORTED
-            )
-
-            // Register Featured Cluster Publish Intent
-            ContextCompat.registerReceiver(
-                appContext,
-                receiver,
-                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
-                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
-                null,
-                ContextCompat.RECEIVER_EXPORTED
-            )
-
-            // Register Continuation Cluster Publish Intent
-            ContextCompat.registerReceiver(
-                appContext,
-                receiver,
-                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                filter,
                 BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
                 null,
                 ContextCompat.RECEIVER_EXPORTED

--- a/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageBroadcastReceiver.kt
@@ -1,0 +1,78 @@
+package com.example.snippets.engage
+
+// [START android_engage_broadcast_receiver_implementation]
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import com.google.android.engage.service.BroadcastReceiverPermissions
+
+// [START_EXCLUDE silent]
+@SuppressWarnings("unused")
+// [END_EXCLUDE]
+class EngageBroadcastReceiver : BroadcastReceiver() {
+    // IMPORTANT: Only trigger the specific publish job for the received intent action.
+    // DO NOT publish all clusters at once.
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent == null || context == null) return
+        when (intent.action) {
+            com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION
+                -> EngagePublisher.publishOneTime(context,Constants.PUBLISH_TYPE_RECOMMENDATIONS)
+            // Note: If app handles other publish actions (e.g. Featured, Continuation), add them here.
+            com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED
+                -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FEATURED)
+
+            /** Note: If vertical has other intents (e.g. FOOD shopping cart, etc.), add them here.
+             * com.google.android.engage.food.service.Intents.ACTION_PUBLISH_FOOD_SHOPPING_CART
+             * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_FOOD_SHOPPING_CARD)
+             * com.google.android.engage.travel.service.Intents.ACTION_PUBLISH_RESERVATION
+             * -> EngagePublisher.publishOneTime(context, Constants.PUBLISH_TYPE_RESERVATION )
+            **/
+        }
+    }
+
+    companion object {
+        /**
+         * Dynamically registers the receiver.
+         * This is required in addition to static registration in AndroidManifest.xml.
+         * Call this method in your Application's onCreate() or your main Activity's onCreate().
+         */
+        fun register(context: Context) {
+            val appContext = context.applicationContext
+            val receiver = EngageBroadcastReceiver()
+
+            // Register Recommendation Cluster Publish Intent
+            ContextCompat.registerReceiver(
+                appContext,
+                receiver,
+                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_RECOMMENDATION),
+                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                null,
+                ContextCompat.RECEIVER_EXPORTED
+            )
+
+            // Register Featured Cluster Publish Intent
+            ContextCompat.registerReceiver(
+                appContext,
+                receiver,
+                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_FEATURED),
+                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                null,
+                ContextCompat.RECEIVER_EXPORTED
+            )
+
+            // Register Continuation Cluster Publish Intent
+            ContextCompat.registerReceiver(
+                appContext,
+                receiver,
+                IntentFilter(com.google.android.engage.service.Intents.ACTION_PUBLISH_CONTINUATION),
+                BroadcastReceiverPermissions.BROADCAST_REQUEST_DATA_PUBLISH_PERMISSION,
+                null,
+                ContextCompat.RECEIVER_EXPORTED
+            )
+            // Note: Add vertical-specific intents here if applicable (e.g., FOOD shopping cart, etc.)
+        }
+    }
+}
+// [END android_engage_broadcast_receiver_implementation]

--- a/misc/src/main/java/com/example/snippets/engage/EngagePublisher.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngagePublisher.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 import android.content.Context
@@ -13,7 +29,7 @@ import java.util.concurrent.TimeUnit
 // [START android_engage_publisher_implementation]
 object EngagePublisher {
 
-    fun publishPeriodically(context: Context, publishType : String) {
+    fun publishPeriodically(context: Context, publishType: String) {
         val workRequest = PeriodicWorkRequestBuilder<EngageWorker>(Constants.REPEAT_INTERVAL, TimeUnit.HOURS)
             .setInputData(workDataOf(Constants.PUBLISH_TYPE_KEY to publishType))
             .build()

--- a/misc/src/main/java/com/example/snippets/engage/EngagePublisher.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngagePublisher.kt
@@ -1,0 +1,31 @@
+package com.example.snippets.engage
+
+import android.content.Context
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+
+@SuppressWarnings("unused")
+// [START android_engage_publisher_implementation]
+object EngagePublisher {
+
+    fun publishPeriodically(context: Context, publishType : String) {
+        val workRequest = PeriodicWorkRequestBuilder<EngageWorker>(Constants.REPEAT_INTERVAL, TimeUnit.HOURS)
+            .setInputData(workDataOf(Constants.PUBLISH_TYPE_KEY to publishType))
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork("EngagePeriodic", ExistingPeriodicWorkPolicy.KEEP, workRequest)
+    }
+
+    fun publishOneTime(context: Context, publishType: String) {
+
+        val workRequest = OneTimeWorkRequestBuilder<EngageWorker>()
+            .setInputData(workDataOf(Constants.PUBLISH_TYPE_KEY to publishType))
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork("EngageOneTime", ExistingWorkPolicy.REPLACE, workRequest)
+    }
+}
+// [END android_engage_publisher_implementation]

--- a/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
@@ -1,0 +1,167 @@
+package com.example.snippets.engage
+
+// [START android_engage_worker_implementation]
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.google.android.engage.service.AppEngageErrorCode
+import com.google.android.engage.service.AppEngageException
+import com.google.android.engage.service.AppEngagePublishClient
+import com.google.android.engage.service.AppEngagePublishStatusCode
+import com.google.android.engage.service.PublishStatusRequest
+import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.tasks.await
+
+// [START_EXCLUDE silent]
+@SuppressWarnings("unused")
+// [END_EXCLUDE]
+class EngageWorker(context: Context, workerParams: WorkerParameters) : CoroutineWorker(context, workerParams) {
+    // Replace {AppEngagePublishClient} with the "client" class found in references/schemas/{VERTICAL}.md.
+    // Client class can vary based on app's vertical.
+    // Refer to the references/schemas/{VERTICAL}.md to find the right class.
+    // This is an example of using AppEngagePublishClient.
+    private val client = AppEngagePublishClient(context)
+    private val clusterRequestFactory = ClusterRequestFactory(context)
+
+    override suspend fun doWork(): Result {
+        if (runAttemptCount > Constants.MAX_PUBLISHING_ATTEMPTS) {
+            // If we keep failing, report it as a service error before giving up.
+            updatePublishStatus(AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR)
+            return Result.failure()
+        }
+
+        // Check if engage service is available before publishing.
+        val isAvailable = client.isServiceAvailable.await()
+
+        // If the service is not available, do not attempt to publish and indicate failure.
+        if (!isAvailable) {
+            return Result.failure()
+        }
+
+        val publishType = inputData.getString(Constants.PUBLISH_TYPE_KEY)
+        return when (publishType) {
+            Constants.PUBLISH_TYPE_RECOMMENDATIONS -> publishRecommendations()
+            // Constants.PUBLISH_TYPE_FEATURED -> publishFeatured()
+            // Constants.PUBLISH_TYPE_CONTINUATION-> publishContinuation()
+            Constants.PUBLISH_TYPE_USER_ACCOUNT_MANAGEMENT -> publishUserAccountManagement()
+            else -> Result.failure()
+        }
+    }
+
+    // Use similar patterns for other clusters (Featured, Continuation, FoodShoppingList, Reservation etc.)
+    private suspend fun publishRecommendations(): Result {
+        val publishTask: Task<Void> =
+            client.publishRecommendationClusters(
+                clusterRequestFactory.constructRecommendationClustersRequest()
+            )
+        return publishAndProvideResult(publishTask)
+    }
+
+    private suspend fun publishUserAccountManagement(): Result {
+        val publishTask: Task<Void>
+        if (isAccountSignedIn()) {
+            // If signed in, we delete the sign-in card.
+            publishTask = client.deleteUserManagementCluster()
+            return publishAndProvideResult(publishTask)
+        } else {
+            // If not signed in, we publish the sign-in card.
+            // Note: Even though we are publishing a card, the status code is NOT_PUBLISHED_REQUIRES_SIGN_IN
+            // because the actual content (recommendations/continuation) is not published.
+            publishTask =
+                client.publishUserAccountManagementRequest(
+                    clusterRequestFactory.constructUserAccountManagementClusterRequest()
+                )
+            return try {
+                publishTask.await()
+                updatePublishStatus(AppEngagePublishStatusCode.NOT_PUBLISHED_REQUIRES_SIGN_IN)
+                Result.success()
+            } catch (publishException: Exception) {
+                handlePublishException(publishException)
+            }
+        }
+    }
+
+    private fun isAccountSignedIn(): Boolean {
+        // Implement your app's sign-in check logic here.
+        // [START_EXCLUDE]
+        return true
+        // [END_EXCLUDE]
+    }
+
+    private suspend fun publishAndProvideResult(
+        publishTask: Task<Void>
+    ): Result {
+        return try {
+            // An AppEngageException may occur while publishing, so we may not be able to await the result.
+            publishTask.await()
+            // Update status to PUBLISHED only after successful publication.
+            updatePublishStatus(AppEngagePublishStatusCode.PUBLISHED)
+            Result.success()
+        } catch (publishException: Exception) {
+            handlePublishException(publishException)
+        }
+    }
+
+    private fun handlePublishException(publishException: Exception): Result {
+        logPublishing(publishException as AppEngageException)
+
+        // Map AppEngageException error codes to PublishStatusCodes
+        val errorStatusCode = when (publishException.errorCode) {
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
+                AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
+                AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+            else ->
+                AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
+        }
+        updatePublishStatus(errorStatusCode)
+
+        // Some errors are recoverable, such as a threading issue, some are unrecoverable
+        // such as a cluster not containing all necessary fields. If an error is recoverable, we
+        // should attempt to publish again. Setting the result to retry means WorkManager will
+        // attempt to run the worker again, thus attempting to publish again.
+        return if (isErrorRecoverable(publishException)) Result.retry() else Result.failure()
+    }
+
+    private fun updatePublishStatus(statusCode: Int) {
+        client
+            .updatePublishStatus(PublishStatusRequest.Builder().setStatusCode(statusCode).build())
+            .addOnSuccessListener {
+                Log.i(TAG, "Successfully updated publish status code to $statusCode")
+            }
+            .addOnFailureListener { exception ->
+                Log.e(TAG, "Failed to update publish status code to $statusCode\n${exception.stackTrace}")
+            }
+    }
+
+    private fun logPublishing(exception: AppEngageException) {
+        val message = when (exception.errorCode) {
+            AppEngageErrorCode.SERVICE_NOT_FOUND -> "Service not found"
+            AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE -> "Execution failure"
+            AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> "Service not available"
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED -> "Permission denied"
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT -> "Invalid argument"
+            AppEngageErrorCode.SERVICE_CALL_INTERNAL -> "Internal error"
+            AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED -> "Resource exhausted"
+            else -> "Unknown error"
+        }
+        Log.d(TAG, message)
+    }
+
+    private fun isErrorRecoverable(publishingException: AppEngageException): Boolean {
+        return when (publishingException.errorCode) {
+            // Recoverable Error codes
+            AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE,
+            AppEngageErrorCode.SERVICE_CALL_INTERNAL,
+            AppEngageErrorCode.SERVICE_CALL_RESOURCE_EXHAUSTED -> true
+            // Non recoverable error codes
+            AppEngageErrorCode.SERVICE_NOT_FOUND,
+            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT,
+            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED,
+            AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> false
+            else -> throw IllegalArgumentException(publishingException.localizedMessage)
+        }
+    }
+}
+// [END android_engage_worker_implementation]

--- a/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
@@ -182,7 +182,7 @@ class EngageWorker(context: Context, workerParams: WorkerParameters) : Coroutine
             AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT,
             AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED,
             AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> false
-            else -> throw IllegalArgumentException(publishingException.localizedMessage)
+            else -> false
         }
     }
 }

--- a/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
@@ -20,6 +20,7 @@ package com.example.snippets.engage
 import android.content.Context
 import android.util.Log
 import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.android.engage.service.AppEngageErrorCode
 import com.google.android.engage.service.AppEngageException
@@ -120,24 +121,30 @@ class EngageWorker(context: Context, workerParams: WorkerParameters) : Coroutine
     }
 
     private fun handlePublishException(publishException: Exception): Result {
-        logPublishing(publishException as AppEngageException)
+        val appEngageException = publishException as? AppEngageException
+        if (appEngageException != null) {
+            logPublishing(appEngageException)
 
-        // Map AppEngageException error codes to PublishStatusCodes
-        val errorStatusCode = when (publishException.errorCode) {
-            AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
-                AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
-            AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
-                AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
-            else ->
-                AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
+                // Map AppEngageException error codes to PublishStatusCodes
+                val errorStatusCode = when (appEngageException.errorCode) {
+                    AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
+                        AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+
+                    AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
+                        AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+
+                    else ->
+                        AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
+                }
+            updatePublishStatus(errorStatusCode)
+
+            // Some errors are recoverable, such as a threading issue, some are unrecoverable
+            // such as a cluster not containing all necessary fields. If an error is recoverable, we
+            // should attempt to publish again. Setting the result to retry means WorkManager will
+            // attempt to run the worker again, thus attempting to publish again.
+            return if (isErrorRecoverable(appEngageException)) Result.retry() else Result.failure()
         }
-        updatePublishStatus(errorStatusCode)
-
-        // Some errors are recoverable, such as a threading issue, some are unrecoverable
-        // such as a cluster not containing all necessary fields. If an error is recoverable, we
-        // should attempt to publish again. Setting the result to retry means WorkManager will
-        // attempt to run the worker again, thus attempting to publish again.
-        return if (isErrorRecoverable(publishException)) Result.retry() else Result.failure()
+        return Result.failure()
     }
 
     private fun updatePublishStatus(statusCode: Int) {
@@ -151,8 +158,8 @@ class EngageWorker(context: Context, workerParams: WorkerParameters) : Coroutine
             }
     }
 
-    private fun logPublishing(exception: AppEngageException) {
-        val message = when (exception.errorCode) {
+    private fun logPublishing(publishingException: AppEngageException) {
+        val message = when (publishingException.errorCode) {
             AppEngageErrorCode.SERVICE_NOT_FOUND -> "Service not found"
             AppEngageErrorCode.SERVICE_CALL_EXECUTION_FAILURE -> "Execution failure"
             AppEngageErrorCode.SERVICE_NOT_AVAILABLE -> "Service not available"

--- a/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
@@ -20,7 +20,6 @@ package com.example.snippets.engage
 import android.content.Context
 import android.util.Log
 import androidx.work.CoroutineWorker
-import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.google.android.engage.service.AppEngageErrorCode
 import com.google.android.engage.service.AppEngageException
@@ -125,17 +124,17 @@ class EngageWorker(context: Context, workerParams: WorkerParameters) : Coroutine
         if (appEngageException != null) {
             logPublishing(appEngageException)
 
-                // Map AppEngageException error codes to PublishStatusCodes
-                val errorStatusCode = when (appEngageException.errorCode) {
-                    AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
-                        AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+            // Map AppEngageException error codes to PublishStatusCodes
+            val errorStatusCode = when (appEngageException.errorCode) {
+                AppEngageErrorCode.SERVICE_CALL_INVALID_ARGUMENT ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
 
-                    AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
-                        AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
+                AppEngageErrorCode.SERVICE_CALL_PERMISSION_DENIED ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_CLIENT_ERROR
 
-                    else ->
-                        AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
-                }
+                else ->
+                    AppEngagePublishStatusCode.NOT_PUBLISHED_SERVICE_ERROR
+            }
             updatePublishStatus(errorStatusCode)
 
             // Some errors are recoverable, such as a threading issue, some are unrecoverable

--- a/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
+++ b/misc/src/main/java/com/example/snippets/engage/EngageWorker.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 // [START android_engage_worker_implementation]

--- a/misc/src/main/java/com/example/snippets/engage/ItemToEntityConverter.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ItemToEntityConverter.kt
@@ -1,0 +1,18 @@
+package com.example.snippets.engage
+
+import com.google.android.engage.books.datamodel.EbookEntity
+
+// [START android_engage_item_to_entity_converter_implementation]
+object ItemToEntityConverter {
+    // Converts app's local models to appropriate engage entity models.
+    // Use `{VERTICAL}.md` in the `references/schemas/` directory to identify the correct Engage entities.
+    // This is an example of using EbookEntity model.
+    fun convert(item: AppData): EbookEntity {
+        return EbookEntity.Builder()
+            // Implement required data mapping logic here.
+            .setName(item.title)
+            .addAuthor(item.author)
+            .build()
+    }
+}
+// [END android_engage_item_to_entity_converter_implementation]

--- a/misc/src/main/java/com/example/snippets/engage/ItemToEntityConverter.kt
+++ b/misc/src/main/java/com/example/snippets/engage/ItemToEntityConverter.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.example.snippets.engage
 
 import com.google.android.engage.books.datamodel.EbookEntity

--- a/misc/src/main/res/values/strings.xml
+++ b/misc/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
 -->
 <resources>
     <string name="app_name">Background Snippets</string>
+    <string name="sign_in_card_action_text">Sign In</string>
 </resources>


### PR DESCRIPTION
* `EngageWorker` and `EngagePublisher` for background data publishing using WorkManager
* `EngageBroadcastReceiver` for handling SDK publish intents
* `ClusterRequestFactory` and `ItemToEntityConverter` for data mapping
* `Constants` for holding common values like attempt counts, publish types etc.
* Update `AndroidManifest.xml` with required permissions and receiver configuration
* Add `engage-core` dependency and associated constants