### PR TITLE
Fix password state in text field migration snippet

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/text/TextFieldMigrationSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/text/TextFieldMigrationSnippets.kt
@@ -333,8 +333,8 @@ private object ViewModelMigrationNewConformingSnippet {
             TextField(usernameState)
 
             val passwordState = rememberTextFieldState(initialUiState.password)
-            LaunchedEffect(usernameState) {
-                snapshotFlow { usernameState.text.toString() }.collectLatest {
+            LaunchedEffect(passwordState, loginViewModel) {
+                snapshotFlow { passwordState.text.toString() }.collectLatest {
                     loginViewModel.updatePassword(it)
                 }
             }

--- a/compose/snippets/src/main/java/com/example/compose/snippets/text/TextFieldMigrationSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/text/TextFieldMigrationSnippets.kt
@@ -333,7 +333,7 @@ private object ViewModelMigrationNewConformingSnippet {
             TextField(usernameState)
 
             val passwordState = rememberTextFieldState(initialUiState.password)
-            LaunchedEffect(passwordState, loginViewModel) {
+            LaunchedEffect(passwordState) {
                 snapshotFlow { passwordState.text.toString() }.collectLatest {
                     loginViewModel.updatePassword(it)
                 }


### PR DESCRIPTION
* Use passwordState for the password LaunchedEffect key
* Read passwordState in the snapshotFlow before updating the password
* Fixes #783

This corrects a copy-paste error in the text field migration snippet.

Test: ANDROID_HOME=/Users/Dheeraj/Library/Android/sdk ./gradlew :compose:snippets:compileDebugKotlin