### PR TITLE
Fix Navigation 3 scene metadata key checks

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/navigation3/scenes/ScenesSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/navigation3/scenes/ScenesSnippets.kt
@@ -124,8 +124,8 @@ class ListDetailSceneStrategy<T : Any>(val windowSizeClass: WindowSizeClass) : S
         }
 
         val detailEntry =
-            entries.lastOrNull()?.takeIf { it.metadata.contains(DetailKey) } ?: return null
-        val listEntry = entries.findLast { it.metadata.contains(ListKey) } ?: return null
+            entries.lastOrNull()?.takeIf { DetailKey in it.metadata } ?: return null
+        val listEntry = entries.findLast { ListKey in it.metadata } ?: return null
 
         // We use the list's contentKey to uniquely identify the scene.
         // This allows the detail panes to be displayed instantly through recomposition, rather than


### PR DESCRIPTION
* Check Navigation 3 scene metadata using string map keys
* Remove the unused metadata contains helper import
* Fixes #841

This makes the list-detail scene snippet explicit about looking up entries in NavEntry metadata by String key.

Test: ANDROID_HOME=/Users/Dheeraj/Library/Android/sdk ./gradlew :compose:snippets:compileDebugKotlin