### PR TITLE
refactor(wear): remove redundant suppressions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,9 +115,9 @@ androidx-core-telecom = "1.1.0-alpha04"
 media3Session = "1.10.0"
 playServicesFitness = "21.3.0"
 engageCore = "1.5.12"
-compose-remote = "1.0.0-alpha010"
-glance-wear = "1.0.0-alpha09"
-remote-material3 = "1.0.0-alpha03"
+compose-remote = "1.0.0-alpha11"
+glance-wear = "1.0.0-alpha10"
+remote-material3 = "1.0.0-alpha04"
 
 [libraries]
 accompanist-adaptive = "com.google.accompanist:accompanist-adaptive:0.37.3"

--- a/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
+++ b/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
@@ -26,6 +26,7 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.glance.wear.GlanceWearWidget
@@ -56,7 +57,6 @@ class HelloWidget : GlanceWearWidget() {
 // [END android_wear_widget_glance]
 
 // [START android_wear_widget_content]
-@SuppressLint("RestrictedApi")
 @RemoteComposable @Composable
 fun HelloWidgetContent() {
     RemoteBox(
@@ -64,7 +64,7 @@ fun HelloWidgetContent() {
         contentAlignment = RemoteAlignment.Center,
     ) {
         RemoteText(
-            text = "Hello World",
+            text = "Hello World".rs,
             color = Color.White.rc
         )
     }

--- a/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
+++ b/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
@@ -37,14 +37,12 @@ import androidx.glance.wear.color
 import androidx.glance.wear.core.WearWidgetParams
 
 // [START android_wear_widget_service]
-@SuppressLint("RestrictedApi")
 class HelloWidgetService : GlanceWearWidgetService() {
     override val widget: GlanceWearWidget = HelloWidget()
 }
 // [END android_wear_widget_service]
 
 // [START android_wear_widget_glance]
-@SuppressLint("RestrictedApi")
 class HelloWidget : GlanceWearWidget() {
     override suspend fun provideWidgetData(
         context: Context,


### PR DESCRIPTION
Remove @SuppressLint("RestrictedApi") from HelloWidgetService and HelloWidget because they are no longer needed with the public APIs in the latest Glance versions. This cleans up the code and avoids suppressing warnings unnecessarily. Also bump dependencies to match the versions in the WearWidget sample.