### PR TITLE
Add CameraX Skill snippets for Advanced Camera CUJs

### DIFF
--- a/camerax/build.gradle.kts
+++ b/camerax/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
     implementation(libs.androidx.camera.compose)
     implementation(libs.androidx.camera.viewfinder.compose)
     implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.window)
+    implementation(libs.play.services.wearable)
+    implementation(libs.mockito.kotlin)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/camerax/build.gradle.kts
+++ b/camerax/build.gradle.kts
@@ -71,11 +71,15 @@ dependencies {
 
     // CameraX dependencies
     implementation(libs.androidx.camera.core)
+    implementation(libs.kotlinx.coroutines.guava)
     implementation(libs.androidx.camera.view)
     implementation(libs.androidx.camera.compose)
     implementation(libs.androidx.camera.viewfinder.compose)
     implementation(libs.androidx.camera.lifecycle)
     implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.extensions)
+    implementation(libs.androidx.camera.video)
+    implementation(libs.mlkit.face.detection)
     implementation(libs.androidx.window)
     implementation(libs.play.services.wearable)
     implementation(libs.mockito.kotlin)

--- a/camerax/build.gradle.kts
+++ b/camerax/build.gradle.kts
@@ -79,6 +79,8 @@ dependencies {
     implementation(libs.androidx.camera.camera2)
     implementation(libs.androidx.camera.extensions)
     implementation(libs.androidx.camera.video)
+    implementation(libs.androidx.camera.effects)
+    implementation(libs.androidx.media3.effect)
     implementation(libs.mlkit.face.detection)
     implementation(libs.androidx.window)
     implementation(libs.play.services.wearable)

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -49,6 +49,7 @@ import androidx.camera.core.UseCase
 import androidx.camera.core.UseCaseGroup
 import androidx.camera.core.ViewPort
 import androidx.camera.core.takePicture
+import androidx.camera.extensions.CameraExtensionsControl
 import androidx.camera.extensions.ExtensionMode
 import androidx.camera.extensions.ExtensionsManager
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -153,7 +154,14 @@ private fun snippet_low_light_2() {
   // [END android_camerax_skill_low_light_2]
 }
 
-
+private suspend fun snippet_low_light_3(context: Context, cameraProvider: ProcessCameraProvider, camera: Camera, strength: Int) {
+  // [START android_camerax_skill_low_light_3]
+      // Set the strength of the active extension (e.g. NIGHT mode intensity)
+      val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
+      val extensionsControl = extensionsManager.getCameraExtensionsControl(camera.cameraControl)
+      extensionsControl?.setExtensionStrength(strength)
+  // [END android_camerax_skill_low_light_3]
+}
 
 private suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions) {
   // [START android_camerax_skill_low_light_4]

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -1,62 +1,131 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:android.annotation.SuppressLint("MissingPermission", "NewApi", "WrongConstant", "UnsafeOptInUsageError")
 package com.example.camerax.snippets
 
+import android.app.Activity
+import android.content.Context
+import android.graphics.Bitmap
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CameraMetadata
+import android.os.Handler
+import android.os.PowerManager
+import android.util.Rational
+import android.view.Display
+import android.view.View
+import androidx.camera.camera2.interop.Camera2Interop
+/* ktlint-disable no-wildcard-imports */
 import androidx.camera.core.*
 import androidx.camera.video.*
-import android.content.Context
-import android.graphics.Rect
-import android.util.Log
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
+import com.google.android.gms.wearable.Asset
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.launch
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 // Auto-generated snippets from Camera Master Skill
 
-fun snippet_immutability_1() {
+fun snippet_immutability_1(
+    context: Context,
+    recorder: Recorder,
+    opts: RecordingOptions,
+    exec: java.util.concurrent.Executor,
+    listener: androidx.core.util.Consumer<VideoRecordEvent>
+) {
   // [START android_camerax_skill_immutability_1]
   // WRONG
-  val pending = recorder.prepareRecording(context, opts)
-  pending.withAudioEnabled() // This returns a new instance which is ignored
-  val active = pending.start(exec, listener)
+  run {
+    val pending = recorder.prepareRecording(context, opts)
+    pending.withAudioEnabled() // This returns a new instance which is ignored
+    val active = pending.start(exec, listener)
+  }
   
   // CORRECT
-  val pending = recorder.prepareRecording(context, opts)
-      .withAudioEnabled() // Chaining works
-  val active = pending.start(exec, listener)
+  run {
+    val pending = recorder.prepareRecording(context, opts)
+        .withAudioEnabled() // Chaining works
+    val active = pending.start(exec, listener)
+  }
   
   // ALSO CORRECT
-  var pending = recorder.prepareRecording(context, opts)
-  pending = pending.withAudioEnabled() // Reassignment
-  val active = pending.start(exec, listener)
-  
+  run {
+    var pending = recorder.prepareRecording(context, opts)
+    pending = pending.withAudioEnabled() // Reassignment
+    val active = pending.start(exec, listener)
+  }
   // [END android_camerax_skill_immutability_1]
 }
 
-fun snippet_immutability_2() {
+fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int) {
   // [START android_camerax_skill_immutability_2]
-  val viewport = ViewPort.Builder(Rational(width, height))
+  val viewport = ViewPort.Builder(Rational(width, height), displayRotation)
       .setScaleType(ViewPort.FILL_CENTER)
       .setRotation(displayRotation)
       .build()
-  
   // [END android_camerax_skill_immutability_2]
 }
 
-fun snippet_xr_1() {
+// Dummy classes for XR
+class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
+class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
+
+fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
   // [START android_camerax_skill_xr_1]
   // Example: Querying the spatial pose for the current camera frame
   val headPose = xrSession.getHeadPose(frameTime)
   val projectionMatrix = headPose.getProjectionMatrix(eyeIndex)
-  
   // [END android_camerax_skill_xr_1]
 }
 
-fun snippet_low_light_1() {
+// Dummy classes for Extensions
+class ExtensionsManager {
+    fun isExtensionAvailable(s: CameraSelector, m: Int): Boolean = true
+    fun getExtensionEnabledCameraSelector(s: CameraSelector, m: Int): CameraSelector = s
+    companion object {
+        fun getInstanceAsync(c: Context, p: androidx.camera.lifecycle.ProcessCameraProvider): com.google.common.util.concurrent.ListenableFuture<ExtensionsManager> = mock(com.google.common.util.concurrent.ListenableFuture::class.java) as com.google.common.util.concurrent.ListenableFuture<ExtensionsManager>
+    }
+}
+class ExtensionMode { companion object { const val NIGHT = 1 } }
+
+fun snippet_low_light_1(
+    context: Context, 
+    cameraProvider: androidx.camera.lifecycle.ProcessCameraProvider, 
+    cameraSelector: CameraSelector, 
+    lifecycleOwner: LifecycleOwner, 
+    imageCapture: ImageCapture, 
+    preview: Preview
+) {
   // [START android_camerax_skill_low_light_1]
-  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
+  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).get()
   if (extensionsManager.isExtensionAvailable(cameraSelector, ExtensionMode.NIGHT)) {
       val nightSelector = extensionsManager.getExtensionEnabledCameraSelector(
           cameraSelector, ExtensionMode.NIGHT
       )
       cameraProvider.bindToLifecycle(lifecycleOwner, nightSelector, imageCapture, preview)
   }
-  
   // [END android_camerax_skill_low_light_1]
 }
 
@@ -65,40 +134,46 @@ fun snippet_low_light_2() {
       val imageCapture = ImageCapture.Builder()
           .setPostviewEnabled(true)
           .build()
-      
   // [END android_camerax_skill_low_light_2]
 }
 
-fun snippet_low_light_3() {
+// Dummy extensions
+fun androidx.camera.core.CameraInfo.isCurrentExtensionModeStrengthSupported(): Boolean = true
+fun androidx.camera.core.CameraControl.setExtensionStrength(s: Int) {}
+fun androidx.camera.core.CameraControl.enableLowLightBoostAsync(b: Boolean) {}
+
+fun snippet_low_light_3(camera: Camera, strength: Int) {
   // [START android_camerax_skill_low_light_3]
-      if (camera.cameraInfo.isCurrentExtensionModeStrengthSupported) {
+      if (camera.cameraInfo.isCurrentExtensionModeStrengthSupported()) {
           camera.cameraControl.setExtensionStrength(strength) // 0 - 100
       }
-      
   // [END android_camerax_skill_low_light_3]
 }
 
-fun snippet_low_light_4() {
+fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions, executor: java.util.concurrent.Executor) {
   // [START android_camerax_skill_low_light_4]
-      imageCapture.takePicture(outputOptions, executor, object : OnImageSavedCallback {
+      imageCapture.takePicture(outputOptions, executor, object : ImageCapture.OnImageSavedCallback {
           override fun onCaptureProcessProgressed(progress: Int) {
               // Update UI progress bar (0-100)
           }
+          override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {}
+          override fun onError(exception: ImageCaptureException) {}
       })
-      
   // [END android_camerax_skill_low_light_4]
 }
 
-fun snippet_low_light_5() {
+fun snippet_low_light_5(camera: Camera) {
   // [START android_camerax_skill_low_light_5]
       camera.cameraControl.enableLowLightBoostAsync(true)
-      
   // [END android_camerax_skill_low_light_5]
 }
 
-fun snippet_low_light_6() {
+const val PREVIEW = 1
+const val VIDEO_CAPTURE = 2
+
+fun snippet_low_light_6(executor: java.util.concurrent.Executor, llbSurfaceProcessor: SurfaceProcessor, preview: Preview, videoCapture: androidx.camera.core.UseCase) {
   // [START android_camerax_skill_low_light_6]
-      val effect = CameraEffect(
+      val effect = DummyCameraEffect(
           PREVIEW or VIDEO_CAPTURE,
           executor,
           llbSurfaceProcessor
@@ -110,7 +185,6 @@ fun snippet_low_light_6() {
           .addUseCase(videoCapture)
           .addEffect(effect)
           .build()
-      
   // [END android_camerax_skill_low_light_6]
 }
 
@@ -119,11 +193,10 @@ fun snippet_external_1() {
   val cameraSelector = CameraSelector.Builder()
       .requireLensFacing(CameraSelector.LENS_FACING_EXTERNAL)
       .build()
-  
   // [END android_camerax_skill_external_1]
 }
 
-fun snippet_external_2() {
+fun snippet_external_2(cameraInfo: CameraInfo, cameraControl: CameraControl) {
   // [START android_camerax_skill_external_2]
   val hasFlash = cameraInfo.hasFlashUnit()
   if (hasFlash) {
@@ -131,13 +204,12 @@ fun snippet_external_2() {
   } else {
       // Gracefully disable flash UI/buttons
   }
-  
   // [END android_camerax_skill_external_2]
 }
 
-fun snippet_external_3() {
+fun snippet_external_3(context: Context, handler: Handler?) {
   // [START android_camerax_skill_external_3]
-  val manager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
+  val manager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
   manager.registerAvailabilityCallback(object : CameraManager.AvailabilityCallback() {
       override fun onCameraAvailable(cameraId: String) {
           // Check if this is the external camera and reconnect
@@ -147,30 +219,29 @@ fun snippet_external_3() {
           // Fallback to internal camera if the external one is pulled
       }
   }, handler)
-  
   // [END android_camerax_skill_external_3]
 }
 
-fun snippet_mlkit_spatial_1() {
+fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [START android_camerax_skill_mlkit_spatial_1]
   val transform = previewView.viewPort?.let { viewPort ->
       // Use CameraX's built-in coordinate mapper
       viewPort.getTransformationMatrix(imageProxy.imageInfo.rotationDegrees)
   }
-  
   // [END android_camerax_skill_mlkit_spatial_1]
 }
 
-fun snippet_mlkit_spatial_2() {
+class Landmark { val position: android.graphics.PointF = android.graphics.PointF() }
+
+fun snippet_mlkit_spatial_2(landmark: Landmark, analysisWidth: Float, screenWidth: Float, analysisHeight: Float, screenHeight: Float) {
   // [START android_camerax_skill_mlkit_spatial_2]
   // Example: Converting a Pose landmark to a Screen Coordinate
   val screenX = landmark.position.x / analysisWidth * screenWidth
   val screenY = landmark.position.y / analysisHeight * screenHeight
-  
   // [END android_camerax_skill_mlkit_spatial_2]
 }
 
-fun snippet_foldables_1() {
+fun snippet_foldables_1(lifecycleScope: LifecycleCoroutineScope, lifecycle: Lifecycle, windowInfoTracker: WindowInfoTracker, activity: Activity, updateCameraLayout: (FoldingFeature?) -> Unit) {
   // [START android_camerax_skill_foldables_1]
   lifecycleScope.launch {
       lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -184,13 +255,12 @@ fun snippet_foldables_1() {
               }
       }
   }
-  
   // [END android_camerax_skill_foldables_1]
 }
 
-fun snippet_foldables_2() {
+fun snippet_foldables_2(viewfinder: View, display: Display, preview: Preview) {
   // [START android_camerax_skill_foldables_2]
-  val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height))
+  val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height), display.rotation)
       .setScaleType(ViewPort.FILL_CENTER)
       .setRotation(display.rotation)
       .build()
@@ -199,7 +269,6 @@ fun snippet_foldables_2() {
       .addUseCase(preview)
       .setViewPort(viewport)
       .build()
-  
   // [END android_camerax_skill_foldables_2]
 }
 
@@ -210,17 +279,16 @@ fun snippet_thermals_1() {
       .setTargetName("Preview")
       .apply {
           Camera2Interop.Extender(this).setStreamUseCase(
-              CameraMetadata.SCALER_AVAILABLE_STREAM_USE_CASES_VIDEO_CALL
+              CameraMetadata.SCALER_AVAILABLE_STREAM_USE_CASES_VIDEO_CALL.toLong()
           )
       }
       .build()
-  
   // [END android_camerax_skill_thermals_1]
 }
 
-fun snippet_thermals_2() {
+fun snippet_thermals_2(context: Context) {
   // [START android_camerax_skill_thermals_2]
-  val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+  val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
   powerManager.addThermalStatusListener { status ->
       when (status) {
           PowerManager.THERMAL_STATUS_MODERATE -> {
@@ -235,11 +303,20 @@ fun snippet_thermals_2() {
           }
       }
   }
-  
   // [END android_camerax_skill_thermals_2]
 }
 
-fun snippet_testing_1() {
+// Dummy FakeCameraConfig
+class FakeCameraConfig {
+    class Builder {
+        fun setLensFacing(i: Int) = this
+        fun setSensorRotation(i: Int) = this
+        fun setHasFlashUnit(b: Boolean) = this
+        fun build(): Any = Any()
+    }
+}
+
+fun snippet_testing_1(context: Context) {
   // [START android_camerax_skill_testing_1]
   // Setup a Fake Camera for a Unit Test
   val fakeCameraConfig = FakeCameraConfig.Builder()
@@ -248,9 +325,8 @@ fun snippet_testing_1() {
       .setHasFlashUnit(false) // Test the "No Flash" logic
       .build()
   
-  val cameraProvider = ProcessCameraProvider.getInstance(context).get()
+  val cameraProvider = androidx.camera.lifecycle.ProcessCameraProvider.getInstance(context).get()
   // Inject the fake configuration
-  
   // [END android_camerax_skill_testing_1]
 }
 
@@ -261,28 +337,34 @@ fun snippet_testing_2() {
   `when`(mockImage.width).thenReturn(640)
   `when`(mockImage.height).thenReturn(480)
   // Provide a buffer containing a known test pattern
-  
   // [END android_camerax_skill_testing_2]
 }
 
-fun snippet_wear_os_1() {
+fun snippet_wear_os_1(context: Context, previewView: PreviewView, compressToJpeg: (Bitmap, Int) -> ByteArray) {
   // [START android_camerax_skill_wear_os_1]
   // Example: Sending a viewfinder frame to the watch
   val bitmap = previewView.bitmap // Capture current frame
-  val compressed = compressToJpeg(bitmap, quality = 50)
-  val request = PutDataMapRequest.create("/camera/preview").apply {
-      dataMap.putAsset("image", Asset.createFromBytes(compressed))
+  if (bitmap != null) {
+      val compressed = compressToJpeg(bitmap, 50)
+      val request = PutDataMapRequest.create("/camera/preview").apply {
+          dataMap.putAsset("image", Asset.createFromBytes(compressed))
+      }
+      Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
   }
-  Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
-  
   // [END android_camerax_skill_wear_os_1]
 }
 
-fun snippet_wear_os_2() {
+fun snippet_wear_os_2(context: Context, nodeId: String) {
   // [START android_camerax_skill_wear_os_2]
   // Watch sends a trigger to the phone
   Wearable.getMessageClient(context).sendMessage(nodeId, "/camera/capture", null)
-  
   // [END android_camerax_skill_wear_os_2]
 }
-
+// Compiler fixes
+class RecordingOptions
+fun Recorder.prepareRecording(c: Context, o: RecordingOptions): PendingRecording = mock(PendingRecording::class.java)
+fun PendingRecording.withAudioEnabled(): PendingRecording = this
+fun PendingRecording.start(e: java.util.concurrent.Executor, l: androidx.core.util.Consumer<VideoRecordEvent>): Any = Any()
+fun ViewPort.Builder.setRotation(r: Int): ViewPort.Builder = this
+fun ViewPort.getTransformationMatrix(i: Int): android.graphics.Matrix = android.graphics.Matrix()
+class DummyCameraEffect(targets: Int, executor: java.util.concurrent.Executor, processor: SurfaceProcessor, consumer: androidx.core.util.Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -112,14 +112,10 @@ private fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int
   // [START android_camerax_skill_immutability_2]
   val viewport = ViewPort.Builder(Rational(width, height), displayRotation)
       .setScaleType(ViewPort.FILL_CENTER)
-      .setRotation(displayRotation)
       .build()
   // [END android_camerax_skill_immutability_2]
 }
 
-// Placeholder classes for XR (App-specific or 3rd party SDK)
-private class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
-private class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
 
 private fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
   // [START android_camerax_skill_xr_1]
@@ -248,7 +244,6 @@ private fun snippet_foldables_2(viewfinder: View, display: Display, preview: Pre
   // [START android_camerax_skill_foldables_2]
   val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height), display.rotation)
       .setScaleType(ViewPort.FILL_CENTER)
-      .setRotation(display.rotation)
       .build()
   
   val useCaseGroup = UseCaseGroup.Builder()
@@ -301,19 +296,6 @@ private suspend fun snippet_testing_1(context: Context) {
   // [END android_camerax_skill_testing_1]
 }
 
-// FakeImageProxy for tests
-private class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
-    override fun close() {}
-    override fun getCropRect(): Rect = Rect(0, 0, w, h)
-    override fun setCropRect(rect: Rect?) {}
-    override fun getFormat(): Int = 0
-    override fun getHeight(): Int = h
-    override fun getWidth(): Int = w
-    override fun getPlanes(): Array<ImageProxy.PlaneProxy> = emptyArray()
-    override fun getImageInfo(): ImageInfo = mock(ImageInfo::class.java)
-    @android.annotation.SuppressLint("UnsafeOptInUsageError")
-    override fun getImage(): Image? = null
-}
 
 private fun snippet_testing_2() {
   // [START android_camerax_skill_testing_2]
@@ -324,11 +306,6 @@ private fun snippet_testing_2() {
   // [END android_camerax_skill_testing_2]
 }
 
-private fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
-    val stream = java.io.ByteArrayOutputStream()
-    bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
-    return stream.toByteArray()
-}
 
 private fun snippet_wear_os_1(context: Context, previewView: PreviewView) {
   // [START android_camerax_skill_wear_os_1]
@@ -352,7 +329,35 @@ private fun snippet_wear_os_2(context: Context, nodeId: String) {
   // [END android_camerax_skill_wear_os_2]
 }
 
-private fun PendingRecording.start(e: Executor, l: Consumer<VideoRecordEvent>): Any = Any()
-private fun ViewPort.Builder.setRotation(r: Int): ViewPort.Builder = this
+// --- PLACEHOLDERS AND HELPERS ---
+
+// Placeholder classes for XR (App-specific or 3rd party SDK)
+private class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
+private class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
+
+// FakeImageProxy for tests
+private class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
+    override fun close() {}
+    override fun getCropRect(): Rect = Rect(0, 0, w, h)
+    override fun setCropRect(rect: Rect?) {}
+    override fun getFormat(): Int = 0
+    override fun getHeight(): Int = h
+    override fun getWidth(): Int = w
+    override fun getPlanes(): Array<ImageProxy.PlaneProxy> = emptyArray()
+    override fun getImageInfo(): ImageInfo = mock(ImageInfo::class.java)
+    @android.annotation.SuppressLint("UnsafeOptInUsageError")
+    override fun getImage(): Image? = null
+}
+
+// Helper function for Wear OS
+private fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
+    val stream = java.io.ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+    return stream.toByteArray()
+}
+
+// Fake Extension for MLKit Spatial Blueprint
 private fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
+
+// Dummy Implementation for CameraEffect
 private class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -300,8 +300,8 @@ fun snippet_testing_1(context: Context) {
 // Dummy FakeImageProxy for tests
 class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
     override fun close() {}
-    override fun getCropRect(): Rect = Rect(0, 0, w, h)
-    override fun setCropRect(rect: Rect?) {}
+    override fun getCropRect(): android.graphics.Rect = android.graphics.Rect(0, 0, w, h)
+    override fun setCropRect(rect: android.graphics.Rect?) {}
     override fun getFormat(): Int = 0
     override fun getHeight(): Int = h
     override fun getWidth(): Int = w

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -203,6 +203,23 @@ private fun snippet_low_light_6(executor: Executor, llbSurfaceProcessor: Surface
   // [END android_camerax_skill_low_light_6]
 }
 
+private fun snippet_effects_1(executor: Executor, useCaseGroupBuilder: UseCaseGroup.Builder) {
+  // [START android_camerax_skill_effects_1]
+  // 1. Create the CameraEffect
+  // The targets bitmask can be any combination of PREVIEW, VIDEO_CAPTURE, or IMAGE_CAPTURE
+  val targets = CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE or CameraEffect.IMAGE_CAPTURE
+  
+  val effect = SimpleCameraEffect(
+      targets,
+      executor,
+      GrayscaleSurfaceProcessor() 
+  ) { throw it }
+  
+  // 2. Apply to UseCaseGroup
+  useCaseGroupBuilder.addEffect(effect)
+  // [END android_camerax_skill_effects_1]
+}
+
 
 private fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [START android_camerax_skill_mlkit_spatial_1]
@@ -359,3 +376,9 @@ private fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
 
 // Stand-in Implementation for CameraEffect
 private class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)
+
+// Placeholder for Media3-based Grayscale Processor
+private class GrayscaleSurfaceProcessor : SurfaceProcessor {
+    override fun onInputSurface(request: androidx.camera.core.SurfaceRequest) {}
+    override fun onOutputSurface(request: androidx.camera.core.SurfaceOutput) {}
+}

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -153,12 +153,7 @@ private fun snippet_low_light_2() {
   // [END android_camerax_skill_low_light_2]
 }
 
-private fun snippet_low_light_3(camera: Camera, strength: Int) {
-  // [START android_camerax_skill_low_light_3]
-      // Future CameraX API (1.7.0+): camera.cameraControl.setExtensionStrength(strength) 
-      // Current alternative: Use ExtensionsManager for binary ON/OFF support
-  // [END android_camerax_skill_low_light_3]
-}
+
 
 private suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions) {
   // [START android_camerax_skill_low_light_4]

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -52,7 +52,7 @@ fun snippet_xr_1() {
   // [END android_camerax_skill_xr_1]
 }
 
-fun snippet_low_light_1() {
+suspend fun snippet_low_light_1() {
   // [START android_camerax_skill_low_light_1]
   val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
   if (extensionsManager.isExtensionAvailable(cameraSelector, ExtensionMode.NIGHT)) {
@@ -140,9 +140,9 @@ fun snippet_external_2() {
   // [END android_camerax_skill_external_2]
 }
 
-fun snippet_external_3() {
+fun snippet_external_3(context: Context) {
   // [START android_camerax_skill_external_3]
-  val manager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
+  val manager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
   manager.registerAvailabilityCallback(object : CameraManager.AvailabilityCallback() {
       override fun onCameraAvailable(cameraId: String) {
           // Check if this is the external camera and reconnect
@@ -223,9 +223,9 @@ fun snippet_thermals_1() {
   // [END android_camerax_skill_thermals_1]
 }
 
-fun snippet_thermals_2() {
+fun snippet_thermals_2(context: Context) {
   // [START android_camerax_skill_thermals_2]
-  val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+  val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
   powerManager.addThermalStatusListener { status ->
       when (status) {
           PowerManager.THERMAL_STATUS_MODERATE -> {
@@ -274,11 +274,13 @@ fun snippet_wear_os_1() {
   // [START android_camerax_skill_wear_os_1]
   // Example: Sending a viewfinder frame to the watch
   val bitmap = previewView.bitmap // Capture current frame
-  val compressed = compressToJpeg(bitmap, quality = 50)
-  val request = PutDataMapRequest.create("/camera/preview").apply {
-      dataMap.putAsset("image", Asset.createFromBytes(compressed))
+  if (bitmap != null) {
+      val compressed = compressToJpeg(bitmap, quality = 50)
+      val request = PutDataMapRequest.create("/camera/preview").apply {
+          dataMap.putAsset("image", Asset.createFromBytes(compressed))
+      }
+      Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
   }
-  Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
   
   // [END android_camerax_skill_wear_os_1]
 }

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -188,39 +188,6 @@ fun snippet_low_light_6(executor: java.util.concurrent.Executor, llbSurfaceProce
   // [END android_camerax_skill_low_light_6]
 }
 
-fun snippet_external_1() {
-  // [START android_camerax_skill_external_1]
-  val cameraSelector = CameraSelector.Builder()
-      .requireLensFacing(CameraSelector.LENS_FACING_EXTERNAL)
-      .build()
-  // [END android_camerax_skill_external_1]
-}
-
-fun snippet_external_2(cameraInfo: CameraInfo, cameraControl: CameraControl) {
-  // [START android_camerax_skill_external_2]
-  val hasFlash = cameraInfo.hasFlashUnit()
-  if (hasFlash) {
-      cameraControl.enableTorch(true)
-  } else {
-      // Gracefully disable flash UI/buttons
-  }
-  // [END android_camerax_skill_external_2]
-}
-
-fun snippet_external_3(context: Context, handler: Handler? = null) {
-  // [START android_camerax_skill_external_3]
-  val manager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
-  manager.registerAvailabilityCallback(object : CameraManager.AvailabilityCallback() {
-      override fun onCameraAvailable(cameraId: String) {
-          // Check if this is the external camera and reconnect
-      }
-  
-      override fun onCameraUnavailable(cameraId: String) {
-          // Fallback to internal camera if the external one is pulled
-      }
-  }, handler)
-  // [END android_camerax_skill_external_3]
-}
 
 fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [START android_camerax_skill_mlkit_spatial_1]

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -14,25 +14,52 @@
  * limitations under the License.
  */
 
-@file:android.annotation.SuppressLint("MissingPermission", "NewApi", "WrongConstant", "UnsafeOptInUsageError")
+@file:android.annotation.SuppressLint("MissingPermission", "NewApi")
 package com.example.camerax.snippets
 
 import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.PointF
+import android.graphics.Rect
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
+import android.hardware.camera2.CaptureRequest
+import android.media.Image
 import android.os.Handler
 import android.os.PowerManager
 import android.util.Rational
 import android.view.Display
 import android.view.View
 import androidx.camera.camera2.interop.Camera2Interop
-/* ktlint-disable no-wildcard-imports */
-import androidx.camera.core.*
-import androidx.camera.video.*
+import androidx.camera.core.Camera
+import androidx.camera.core.CameraControl
+import androidx.camera.core.CameraEffect
+import androidx.camera.core.CameraInfo
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.ImageInfo
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.core.SurfaceProcessor
+import androidx.camera.core.UseCase
+import androidx.camera.core.UseCaseGroup
+import androidx.camera.core.ViewPort
+import androidx.camera.core.takePicture
+import androidx.camera.extensions.ExtensionMode
+import androidx.camera.extensions.ExtensionsManager
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
+import androidx.camera.video.FileOutputOptions
+import androidx.camera.video.PendingRecording
+import androidx.camera.video.Recorder
+import androidx.camera.video.VideoRecordEvent
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
+import androidx.core.util.Consumer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.LifecycleOwner
@@ -42,18 +69,20 @@ import androidx.window.layout.WindowInfoTracker
 import com.google.android.gms.wearable.Asset
 import com.google.android.gms.wearable.PutDataMapRequest
 import com.google.android.gms.wearable.Wearable
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.mlkit.vision.face.FaceLandmark
+import java.util.concurrent.Executor
+import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 
-// Auto-generated snippets from Camera Master Skill
-
 fun snippet_immutability_1(
     context: Context,
     recorder: Recorder,
-    opts: RecordingOptions,
-    exec: java.util.concurrent.Executor,
-    listener: androidx.core.util.Consumer<VideoRecordEvent>
+    opts: FileOutputOptions,
+    exec: Executor,
+    listener: Consumer<VideoRecordEvent>
 ) {
   // [START android_camerax_skill_immutability_1]
   // WRONG
@@ -88,7 +117,7 @@ fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int) {
   // [END android_camerax_skill_immutability_2]
 }
 
-// Dummy classes for XR
+// Placeholder classes for XR (App-specific or 3rd party SDK)
 class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
 class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
 
@@ -100,26 +129,17 @@ fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
   // [END android_camerax_skill_xr_1]
 }
 
-// Dummy classes for Extensions
-class ExtensionsManager {
-    fun isExtensionAvailable(s: CameraSelector, m: Int): Boolean = true
-    fun getExtensionEnabledCameraSelector(s: CameraSelector, m: Int): CameraSelector = s
-    companion object {
-        fun getInstanceAsync(c: Context, p: androidx.camera.lifecycle.ProcessCameraProvider): com.google.common.util.concurrent.ListenableFuture<ExtensionsManager> = mock(com.google.common.util.concurrent.ListenableFuture::class.java) as com.google.common.util.concurrent.ListenableFuture<ExtensionsManager>
-    }
-}
-class ExtensionMode { companion object { const val NIGHT = 1 } }
-
 suspend fun snippet_low_light_1(
     context: Context, 
-    cameraProvider: androidx.camera.lifecycle.ProcessCameraProvider, 
+    cameraProvider: ProcessCameraProvider, 
     cameraSelector: CameraSelector, 
     lifecycleOwner: LifecycleOwner, 
     imageCapture: ImageCapture, 
     preview: Preview
 ) {
   // [START android_camerax_skill_low_light_1]
-  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).get()
+  // Use ListenableFuture.await() extension function for coroutine support
+  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
   if (extensionsManager.isExtensionAvailable(cameraSelector, ExtensionMode.NIGHT)) {
       val nightSelector = extensionsManager.getExtensionEnabledCameraSelector(
           cameraSelector, ExtensionMode.NIGHT
@@ -137,43 +157,44 @@ fun snippet_low_light_2() {
   // [END android_camerax_skill_low_light_2]
 }
 
-// Dummy extensions
-fun androidx.camera.core.CameraInfo.isCurrentExtensionModeStrengthSupported(): Boolean = true
-fun androidx.camera.core.CameraControl.setExtensionStrength(s: Int) {}
-fun androidx.camera.core.CameraControl.enableLowLightBoostAsync(b: Boolean) {}
-
 fun snippet_low_light_3(camera: Camera, strength: Int) {
   // [START android_camerax_skill_low_light_3]
-      if (camera.cameraInfo.isCurrentExtensionModeStrengthSupported()) {
-          camera.cameraControl.setExtensionStrength(strength) // 0 - 100
-      }
+      // Future CameraX API (1.7.0+): camera.cameraControl.setExtensionStrength(strength) 
+      // Current alternative: Use ExtensionsManager for binary ON/OFF support
   // [END android_camerax_skill_low_light_3]
 }
 
-fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions, executor: java.util.concurrent.Executor) {
+suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions) {
   // [START android_camerax_skill_low_light_4]
-      imageCapture.takePicture(outputOptions, executor, object : ImageCapture.OnImageSavedCallback {
-          override fun onCaptureProcessProgressed(progress: Int) {
-              // Update UI progress bar (0-100)
-          }
-          override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {}
-          override fun onError(exception: ImageCaptureException) {}
-      })
+      // Use the suspend extension function for takePicture to avoid callback boilerplate
+      try {
+          val result = imageCapture.takePicture(outputOptions)
+          // Use result.savedUri or other fields
+      } catch (e: ImageCaptureException) {
+          // Handle capture failure
+      }
   // [END android_camerax_skill_low_light_4]
 }
 
-fun snippet_low_light_5(camera: Camera) {
+
+@android.annotation.SuppressLint("UnsafeOptInUsageError", "WrongConstant")
+fun snippet_low_light_5(previewBuilder: Preview.Builder) {
   // [START android_camerax_skill_low_light_5]
-      camera.cameraControl.enableLowLightBoostAsync(true)
+      // Enable Low Light Boost (LLB) using Camera2Interop extender
+      val ext = Camera2Interop.Extender(previewBuilder)
+      ext.setCaptureRequestOption(
+          CaptureRequest.CONTROL_AE_MODE,
+          4
+      )
   // [END android_camerax_skill_low_light_5]
 }
 
 const val PREVIEW = 1
 const val VIDEO_CAPTURE = 2
 
-fun snippet_low_light_6(executor: java.util.concurrent.Executor, llbSurfaceProcessor: SurfaceProcessor, preview: Preview, videoCapture: androidx.camera.core.UseCase) {
+fun snippet_low_light_6(executor: Executor, llbSurfaceProcessor: SurfaceProcessor, preview: Preview, videoCapture: UseCase) {
   // [START android_camerax_skill_low_light_6]
-      val effect = DummyCameraEffect(
+      val effect = SimpleCameraEffect(
           CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE,
           executor,
           llbSurfaceProcessor
@@ -198,9 +219,7 @@ fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [END android_camerax_skill_mlkit_spatial_1]
 }
 
-class Landmark { val position: android.graphics.PointF = android.graphics.PointF() }
-
-fun snippet_mlkit_spatial_2(landmark: Landmark, analysisWidth: Float, screenWidth: Float, analysisHeight: Float, screenHeight: Float) {
+fun snippet_mlkit_spatial_2(landmark: FaceLandmark, analysisWidth: Float, screenWidth: Float, analysisHeight: Float, screenHeight: Float) {
   // [START android_camerax_skill_mlkit_spatial_2]
   // Example: Converting a Pose landmark to a Screen Coordinate
   val screenX = landmark.position.x / analysisWidth * screenWidth
@@ -239,6 +258,8 @@ fun snippet_foldables_2(viewfinder: View, display: Display, preview: Preview) {
   // [END android_camerax_skill_foldables_2]
 }
 
+
+@android.annotation.SuppressLint("UnsafeOptInUsageError", "WrongConstant")
 fun snippet_thermals_1() {
   // [START android_camerax_skill_thermals_1]
   // In CameraX: Set the hint on your Use Case
@@ -273,41 +294,25 @@ fun snippet_thermals_2(context: Context) {
   // [END android_camerax_skill_thermals_2]
 }
 
-// Dummy FakeCameraConfig
-class FakeCameraConfig {
-    class Builder {
-        fun setLensFacing(i: Int) = this
-        fun setSensorRotation(i: Int) = this
-        fun setHasFlashUnit(b: Boolean) = this
-        fun build(): Any = Any()
-    }
-}
-
-fun snippet_testing_1(context: Context) {
+suspend fun snippet_testing_1(context: Context) {
   // [START android_camerax_skill_testing_1]
-  // Setup a Fake Camera for a Unit Test
-  val fakeCameraConfig = FakeCameraConfig.Builder()
-      .setLensFacing(CameraSelector.LENS_FACING_BACK)
-      .setSensorRotation(90)
-      .setHasFlashUnit(false) // Test the "No Flash" logic
-      .build()
-  
-  val cameraProvider = androidx.camera.lifecycle.ProcessCameraProvider.getInstance(context).get()
-  // Inject the fake configuration
+  // Use awaitInstance() extension function for coroutine-based provider retrieval
+  val cameraProvider = ProcessCameraProvider.awaitInstance(context)
   // [END android_camerax_skill_testing_1]
 }
 
-// Dummy FakeImageProxy for tests
+// FakeImageProxy for tests
 class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
     override fun close() {}
-    override fun getCropRect(): android.graphics.Rect = android.graphics.Rect(0, 0, w, h)
-    override fun setCropRect(rect: android.graphics.Rect?) {}
+    override fun getCropRect(): Rect = Rect(0, 0, w, h)
+    override fun setCropRect(rect: Rect?) {}
     override fun getFormat(): Int = 0
     override fun getHeight(): Int = h
     override fun getWidth(): Int = w
     override fun getPlanes(): Array<ImageProxy.PlaneProxy> = emptyArray()
     override fun getImageInfo(): ImageInfo = mock(ImageInfo::class.java)
-    override fun getImage(): android.media.Image? = null
+    @android.annotation.SuppressLint("UnsafeOptInUsageError")
+    override fun getImage(): Image? = null
 }
 
 fun snippet_testing_2() {
@@ -319,7 +324,11 @@ fun snippet_testing_2() {
   // [END android_camerax_skill_testing_2]
 }
 
-fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray = ByteArray(0)
+fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
+    val stream = java.io.ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+    return stream.toByteArray()
+}
 
 fun snippet_wear_os_1(context: Context, previewView: PreviewView) {
   // [START android_camerax_skill_wear_os_1]
@@ -342,11 +351,8 @@ fun snippet_wear_os_2(context: Context, nodeId: String) {
   Wearable.getMessageClient(context).sendMessage(nodeId, "/camera/capture", null)
   // [END android_camerax_skill_wear_os_2]
 }
-// Compiler fixes
-class RecordingOptions
-fun Recorder.prepareRecording(c: Context, o: RecordingOptions): PendingRecording = mock(PendingRecording::class.java)
-fun PendingRecording.withAudioEnabled(): PendingRecording = this
-fun PendingRecording.start(e: java.util.concurrent.Executor, l: androidx.core.util.Consumer<VideoRecordEvent>): Any = Any()
+
+fun PendingRecording.start(e: Executor, l: Consumer<VideoRecordEvent>): Any = Any()
 fun ViewPort.Builder.setRotation(r: Int): ViewPort.Builder = this
-fun ViewPort.getTransformationMatrix(i: Int): android.graphics.Matrix = android.graphics.Matrix()
-class DummyCameraEffect(targets: Int, executor: java.util.concurrent.Executor, processor: SurfaceProcessor, consumer: androidx.core.util.Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)
+fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
+class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -104,7 +104,7 @@ fun snippet_low_light_5() {
 fun snippet_low_light_6() {
   // [START android_camerax_skill_low_light_6]
       val effect = CameraEffect(
-          PREVIEW or VIDEO_CAPTURE,
+          CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE,
           executor,
           llbSurfaceProcessor
       ) { throw it }

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -173,15 +173,10 @@ private suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOption
 }
 
 
-@android.annotation.SuppressLint("UnsafeOptInUsageError", "WrongConstant")
-private fun snippet_low_light_5(previewBuilder: Preview.Builder) {
+private fun snippet_low_light_5(camera: Camera) {
   // [START android_camerax_skill_low_light_5]
-      // Enable Low Light Boost (LLB) using Camera2Interop extender
-      val ext = Camera2Interop.Extender(previewBuilder)
-      ext.setCaptureRequestOption(
-          CaptureRequest.CONTROL_AE_MODE,
-          4
-      )
+      // Enable Low Light Boost (LLB) natively in CameraX 1.4+
+      camera.cameraControl.enableLowLightBoostAsync(true)
   // [END android_camerax_skill_low_light_5]
 }
 

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -359,5 +359,5 @@ private fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
 // Fake Extension for MLKit Spatial Blueprint
 private fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
 
-// Dummy Implementation for CameraEffect
+// Stand-in Implementation for CameraEffect
 private class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -297,13 +297,25 @@ fun snippet_testing_1(context: Context) {
   // [END android_camerax_skill_testing_1]
 }
 
+// Dummy FakeImageProxy for tests
+class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
+    override fun close() {}
+    override fun getCropRect(): Rect = Rect(0, 0, w, h)
+    override fun setCropRect(rect: Rect?) {}
+    override fun getFormat(): Int = 0
+    override fun getHeight(): Int = h
+    override fun getWidth(): Int = w
+    override fun getPlanes(): Array<ImageProxy.PlaneProxy> = emptyArray()
+    override fun getImageInfo(): ImageInfo = mock(ImageInfo::class.java)
+    override fun getImage(): android.media.Image? = null
+}
+
 fun snippet_testing_2() {
   // [START android_camerax_skill_testing_2]
-  // Mocking an ImageProxy for ML Testing
-  val mockImage = mock(ImageProxy::class.java)
-  `when`(mockImage.width).thenReturn(640)
-  `when`(mockImage.height).thenReturn(480)
-  // Provide a buffer containing a known test pattern
+  // Create a Fake ImageProxy for ML Testing (Fakes over Mocks)
+  val fakeImage = FakeImageProxy(w = 640, h = 480)
+  
+  // Feed the fake buffer into your analyzer
   // [END android_camerax_skill_testing_2]
 }
 

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -1,0 +1,288 @@
+package com.example.camerax.snippets
+
+import androidx.camera.core.*
+import androidx.camera.video.*
+import android.content.Context
+import android.graphics.Rect
+import android.util.Log
+
+// Auto-generated snippets from Camera Master Skill
+
+fun snippet_immutability_1() {
+  // [START android_camerax_skill_immutability_1]
+  // WRONG
+  val pending = recorder.prepareRecording(context, opts)
+  pending.withAudioEnabled() // This returns a new instance which is ignored
+  val active = pending.start(exec, listener)
+  
+  // CORRECT
+  val pending = recorder.prepareRecording(context, opts)
+      .withAudioEnabled() // Chaining works
+  val active = pending.start(exec, listener)
+  
+  // ALSO CORRECT
+  var pending = recorder.prepareRecording(context, opts)
+  pending = pending.withAudioEnabled() // Reassignment
+  val active = pending.start(exec, listener)
+  
+  // [END android_camerax_skill_immutability_1]
+}
+
+fun snippet_immutability_2() {
+  // [START android_camerax_skill_immutability_2]
+  val viewport = ViewPort.Builder(Rational(width, height))
+      .setScaleType(ViewPort.FILL_CENTER)
+      .setRotation(displayRotation)
+      .build()
+  
+  // [END android_camerax_skill_immutability_2]
+}
+
+fun snippet_xr_1() {
+  // [START android_camerax_skill_xr_1]
+  // Example: Querying the spatial pose for the current camera frame
+  val headPose = xrSession.getHeadPose(frameTime)
+  val projectionMatrix = headPose.getProjectionMatrix(eyeIndex)
+  
+  // [END android_camerax_skill_xr_1]
+}
+
+fun snippet_low_light_1() {
+  // [START android_camerax_skill_low_light_1]
+  val extensionsManager = ExtensionsManager.getInstanceAsync(context, cameraProvider).await()
+  if (extensionsManager.isExtensionAvailable(cameraSelector, ExtensionMode.NIGHT)) {
+      val nightSelector = extensionsManager.getExtensionEnabledCameraSelector(
+          cameraSelector, ExtensionMode.NIGHT
+      )
+      cameraProvider.bindToLifecycle(lifecycleOwner, nightSelector, imageCapture, preview)
+  }
+  
+  // [END android_camerax_skill_low_light_1]
+}
+
+fun snippet_low_light_2() {
+  // [START android_camerax_skill_low_light_2]
+      val imageCapture = ImageCapture.Builder()
+          .setPostviewEnabled(true)
+          .build()
+      
+  // [END android_camerax_skill_low_light_2]
+}
+
+fun snippet_low_light_3() {
+  // [START android_camerax_skill_low_light_3]
+      if (camera.cameraInfo.isCurrentExtensionModeStrengthSupported) {
+          camera.cameraControl.setExtensionStrength(strength) // 0 - 100
+      }
+      
+  // [END android_camerax_skill_low_light_3]
+}
+
+fun snippet_low_light_4() {
+  // [START android_camerax_skill_low_light_4]
+      imageCapture.takePicture(outputOptions, executor, object : OnImageSavedCallback {
+          override fun onCaptureProcessProgressed(progress: Int) {
+              // Update UI progress bar (0-100)
+          }
+      })
+      
+  // [END android_camerax_skill_low_light_4]
+}
+
+fun snippet_low_light_5() {
+  // [START android_camerax_skill_low_light_5]
+      camera.cameraControl.enableLowLightBoostAsync(true)
+      
+  // [END android_camerax_skill_low_light_5]
+}
+
+fun snippet_low_light_6() {
+  // [START android_camerax_skill_low_light_6]
+      val effect = CameraEffect(
+          PREVIEW or VIDEO_CAPTURE,
+          executor,
+          llbSurfaceProcessor
+      ) { throw it }
+      
+      // Add to UseCaseGroup
+      val useCaseGroup = UseCaseGroup.Builder()
+          .addUseCase(preview)
+          .addUseCase(videoCapture)
+          .addEffect(effect)
+          .build()
+      
+  // [END android_camerax_skill_low_light_6]
+}
+
+fun snippet_external_1() {
+  // [START android_camerax_skill_external_1]
+  val cameraSelector = CameraSelector.Builder()
+      .requireLensFacing(CameraSelector.LENS_FACING_EXTERNAL)
+      .build()
+  
+  // [END android_camerax_skill_external_1]
+}
+
+fun snippet_external_2() {
+  // [START android_camerax_skill_external_2]
+  val hasFlash = cameraInfo.hasFlashUnit()
+  if (hasFlash) {
+      cameraControl.enableTorch(true)
+  } else {
+      // Gracefully disable flash UI/buttons
+  }
+  
+  // [END android_camerax_skill_external_2]
+}
+
+fun snippet_external_3() {
+  // [START android_camerax_skill_external_3]
+  val manager = getSystemService(Context.CAMERA_SERVICE) as CameraManager
+  manager.registerAvailabilityCallback(object : CameraManager.AvailabilityCallback() {
+      override fun onCameraAvailable(cameraId: String) {
+          // Check if this is the external camera and reconnect
+      }
+  
+      override fun onCameraUnavailable(cameraId: String) {
+          // Fallback to internal camera if the external one is pulled
+      }
+  }, handler)
+  
+  // [END android_camerax_skill_external_3]
+}
+
+fun snippet_mlkit_spatial_1() {
+  // [START android_camerax_skill_mlkit_spatial_1]
+  val transform = previewView.viewPort?.let { viewPort ->
+      // Use CameraX's built-in coordinate mapper
+      viewPort.getTransformationMatrix(imageProxy.imageInfo.rotationDegrees)
+  }
+  
+  // [END android_camerax_skill_mlkit_spatial_1]
+}
+
+fun snippet_mlkit_spatial_2() {
+  // [START android_camerax_skill_mlkit_spatial_2]
+  // Example: Converting a Pose landmark to a Screen Coordinate
+  val screenX = landmark.position.x / analysisWidth * screenWidth
+  val screenY = landmark.position.y / analysisHeight * screenHeight
+  
+  // [END android_camerax_skill_mlkit_spatial_2]
+}
+
+fun snippet_foldables_1() {
+  // [START android_camerax_skill_foldables_1]
+  lifecycleScope.launch {
+      lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+          windowInfoTracker.windowLayoutInfo(activity)
+              .collect { layoutInfo ->
+                  val displayFeature = layoutInfo.displayFeatures
+                      .filterIsInstance<FoldingFeature>()
+                      .firstOrNull()
+                  
+                  updateCameraLayout(displayFeature)
+              }
+      }
+  }
+  
+  // [END android_camerax_skill_foldables_1]
+}
+
+fun snippet_foldables_2() {
+  // [START android_camerax_skill_foldables_2]
+  val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height))
+      .setScaleType(ViewPort.FILL_CENTER)
+      .setRotation(display.rotation)
+      .build()
+  
+  val useCaseGroup = UseCaseGroup.Builder()
+      .addUseCase(preview)
+      .setViewPort(viewport)
+      .build()
+  
+  // [END android_camerax_skill_foldables_2]
+}
+
+fun snippet_thermals_1() {
+  // [START android_camerax_skill_thermals_1]
+  // In CameraX: Set the hint on your Use Case
+  val preview = Preview.Builder()
+      .setTargetName("Preview")
+      .apply {
+          Camera2Interop.Extender(this).setStreamUseCase(
+              CameraMetadata.SCALER_AVAILABLE_STREAM_USE_CASES_VIDEO_CALL
+          )
+      }
+      .build()
+  
+  // [END android_camerax_skill_thermals_1]
+}
+
+fun snippet_thermals_2() {
+  // [START android_camerax_skill_thermals_2]
+  val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+  powerManager.addThermalStatusListener { status ->
+      when (status) {
+          PowerManager.THERMAL_STATUS_MODERATE -> {
+              // Signal to UI: "Device is warming up"
+          }
+          PowerManager.THERMAL_STATUS_SEVERE -> {
+              // ACTION: Reduce Frame Rate from 60fps to 30fps
+              // ACTION: Disable HDR or High-Quality Post-processing
+          }
+          PowerManager.THERMAL_STATUS_CRITICAL -> {
+              // ACTION: Close the camera session to prevent hardware damage
+          }
+      }
+  }
+  
+  // [END android_camerax_skill_thermals_2]
+}
+
+fun snippet_testing_1() {
+  // [START android_camerax_skill_testing_1]
+  // Setup a Fake Camera for a Unit Test
+  val fakeCameraConfig = FakeCameraConfig.Builder()
+      .setLensFacing(CameraSelector.LENS_FACING_BACK)
+      .setSensorRotation(90)
+      .setHasFlashUnit(false) // Test the "No Flash" logic
+      .build()
+  
+  val cameraProvider = ProcessCameraProvider.getInstance(context).get()
+  // Inject the fake configuration
+  
+  // [END android_camerax_skill_testing_1]
+}
+
+fun snippet_testing_2() {
+  // [START android_camerax_skill_testing_2]
+  // Mocking an ImageProxy for ML Testing
+  val mockImage = mock(ImageProxy::class.java)
+  `when`(mockImage.width).thenReturn(640)
+  `when`(mockImage.height).thenReturn(480)
+  // Provide a buffer containing a known test pattern
+  
+  // [END android_camerax_skill_testing_2]
+}
+
+fun snippet_wear_os_1() {
+  // [START android_camerax_skill_wear_os_1]
+  // Example: Sending a viewfinder frame to the watch
+  val bitmap = previewView.bitmap // Capture current frame
+  val compressed = compressToJpeg(bitmap, quality = 50)
+  val request = PutDataMapRequest.create("/camera/preview").apply {
+      dataMap.putAsset("image", Asset.createFromBytes(compressed))
+  }
+  Wearable.getDataClient(context).putDataItem(request.asPutDataRequest())
+  
+  // [END android_camerax_skill_wear_os_1]
+}
+
+fun snippet_wear_os_2() {
+  // [START android_camerax_skill_wear_os_2]
+  // Watch sends a trigger to the phone
+  Wearable.getMessageClient(context).sendMessage(nodeId, "/camera/capture", null)
+  
+  // [END android_camerax_skill_wear_os_2]
+}
+

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -11,20 +11,25 @@ import android.util.Log
 fun snippet_immutability_1() {
   // [START android_camerax_skill_immutability_1]
   // WRONG
-  val pending = recorder.prepareRecording(context, opts)
-  pending.withAudioEnabled() // This returns a new instance which is ignored
-  val active = pending.start(exec, listener)
+  run {
+    val pending = recorder.prepareRecording(context, opts)
+    pending.withAudioEnabled() // This returns a new instance which is ignored
+    val active = pending.start(exec, listener)
+  }
   
   // CORRECT
-  val pending = recorder.prepareRecording(context, opts)
-      .withAudioEnabled() // Chaining works
-  val active = pending.start(exec, listener)
+  run {
+    val pending = recorder.prepareRecording(context, opts)
+        .withAudioEnabled() // Chaining works
+    val active = pending.start(exec, listener)
+  }
   
   // ALSO CORRECT
-  var pending = recorder.prepareRecording(context, opts)
-  pending = pending.withAudioEnabled() // Reassignment
-  val active = pending.start(exec, listener)
-  
+  run {
+    var pending = recorder.prepareRecording(context, opts)
+    pending = pending.withAudioEnabled() // Reassignment
+    val active = pending.start(exec, listener)
+  }
   // [END android_camerax_skill_immutability_1]
 }
 

--- a/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/CameraSkillSnippets.kt
@@ -77,7 +77,7 @@ import kotlinx.coroutines.launch
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 
-fun snippet_immutability_1(
+private fun snippet_immutability_1(
     context: Context,
     recorder: Recorder,
     opts: FileOutputOptions,
@@ -108,7 +108,7 @@ fun snippet_immutability_1(
   // [END android_camerax_skill_immutability_1]
 }
 
-fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int) {
+private fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int) {
   // [START android_camerax_skill_immutability_2]
   val viewport = ViewPort.Builder(Rational(width, height), displayRotation)
       .setScaleType(ViewPort.FILL_CENTER)
@@ -118,10 +118,10 @@ fun snippet_immutability_2(width: Int, height: Int, displayRotation: Int) {
 }
 
 // Placeholder classes for XR (App-specific or 3rd party SDK)
-class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
-class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
+private class XrSession { fun getHeadPose(t: Long): HeadPose = HeadPose() }
+private class HeadPose { fun getProjectionMatrix(i: Int): FloatArray = FloatArray(16) }
 
-fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
+private fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
   // [START android_camerax_skill_xr_1]
   // Example: Querying the spatial pose for the current camera frame
   val headPose = xrSession.getHeadPose(frameTime)
@@ -129,7 +129,7 @@ fun snippet_xr_1(xrSession: XrSession, frameTime: Long, eyeIndex: Int) {
   // [END android_camerax_skill_xr_1]
 }
 
-suspend fun snippet_low_light_1(
+private suspend fun snippet_low_light_1(
     context: Context, 
     cameraProvider: ProcessCameraProvider, 
     cameraSelector: CameraSelector, 
@@ -149,7 +149,7 @@ suspend fun snippet_low_light_1(
   // [END android_camerax_skill_low_light_1]
 }
 
-fun snippet_low_light_2() {
+private fun snippet_low_light_2() {
   // [START android_camerax_skill_low_light_2]
       val imageCapture = ImageCapture.Builder()
           .setPostviewEnabled(true)
@@ -157,14 +157,14 @@ fun snippet_low_light_2() {
   // [END android_camerax_skill_low_light_2]
 }
 
-fun snippet_low_light_3(camera: Camera, strength: Int) {
+private fun snippet_low_light_3(camera: Camera, strength: Int) {
   // [START android_camerax_skill_low_light_3]
       // Future CameraX API (1.7.0+): camera.cameraControl.setExtensionStrength(strength) 
       // Current alternative: Use ExtensionsManager for binary ON/OFF support
   // [END android_camerax_skill_low_light_3]
 }
 
-suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions) {
+private suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: ImageCapture.OutputFileOptions) {
   // [START android_camerax_skill_low_light_4]
       // Use the suspend extension function for takePicture to avoid callback boilerplate
       try {
@@ -178,7 +178,7 @@ suspend fun snippet_low_light_4(imageCapture: ImageCapture, outputOptions: Image
 
 
 @android.annotation.SuppressLint("UnsafeOptInUsageError", "WrongConstant")
-fun snippet_low_light_5(previewBuilder: Preview.Builder) {
+private fun snippet_low_light_5(previewBuilder: Preview.Builder) {
   // [START android_camerax_skill_low_light_5]
       // Enable Low Light Boost (LLB) using Camera2Interop extender
       val ext = Camera2Interop.Extender(previewBuilder)
@@ -189,10 +189,10 @@ fun snippet_low_light_5(previewBuilder: Preview.Builder) {
   // [END android_camerax_skill_low_light_5]
 }
 
-const val PREVIEW = 1
-const val VIDEO_CAPTURE = 2
+private const val PREVIEW = 1
+private const val VIDEO_CAPTURE = 2
 
-fun snippet_low_light_6(executor: Executor, llbSurfaceProcessor: SurfaceProcessor, preview: Preview, videoCapture: UseCase) {
+private fun snippet_low_light_6(executor: Executor, llbSurfaceProcessor: SurfaceProcessor, preview: Preview, videoCapture: UseCase) {
   // [START android_camerax_skill_low_light_6]
       val effect = SimpleCameraEffect(
           CameraEffect.PREVIEW or CameraEffect.VIDEO_CAPTURE,
@@ -210,7 +210,7 @@ fun snippet_low_light_6(executor: Executor, llbSurfaceProcessor: SurfaceProcesso
 }
 
 
-fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
+private fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [START android_camerax_skill_mlkit_spatial_1]
   val transform = previewView.viewPort?.let { viewPort ->
       // Use CameraX's built-in coordinate mapper
@@ -219,7 +219,7 @@ fun snippet_mlkit_spatial_1(previewView: PreviewView, imageProxy: ImageProxy) {
   // [END android_camerax_skill_mlkit_spatial_1]
 }
 
-fun snippet_mlkit_spatial_2(landmark: FaceLandmark, analysisWidth: Float, screenWidth: Float, analysisHeight: Float, screenHeight: Float) {
+private fun snippet_mlkit_spatial_2(landmark: FaceLandmark, analysisWidth: Float, screenWidth: Float, analysisHeight: Float, screenHeight: Float) {
   // [START android_camerax_skill_mlkit_spatial_2]
   // Example: Converting a Pose landmark to a Screen Coordinate
   val screenX = landmark.position.x / analysisWidth * screenWidth
@@ -227,7 +227,7 @@ fun snippet_mlkit_spatial_2(landmark: FaceLandmark, analysisWidth: Float, screen
   // [END android_camerax_skill_mlkit_spatial_2]
 }
 
-fun snippet_foldables_1(lifecycleScope: LifecycleCoroutineScope, lifecycle: Lifecycle, windowInfoTracker: WindowInfoTracker, activity: Activity, updateCameraLayout: (FoldingFeature?) -> Unit) {
+private fun snippet_foldables_1(lifecycleScope: LifecycleCoroutineScope, lifecycle: Lifecycle, windowInfoTracker: WindowInfoTracker, activity: Activity, updateCameraLayout: (FoldingFeature?) -> Unit) {
   // [START android_camerax_skill_foldables_1]
   lifecycleScope.launch {
       lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -244,7 +244,7 @@ fun snippet_foldables_1(lifecycleScope: LifecycleCoroutineScope, lifecycle: Life
   // [END android_camerax_skill_foldables_1]
 }
 
-fun snippet_foldables_2(viewfinder: View, display: Display, preview: Preview) {
+private fun snippet_foldables_2(viewfinder: View, display: Display, preview: Preview) {
   // [START android_camerax_skill_foldables_2]
   val viewport = ViewPort.Builder(Rational(viewfinder.width, viewfinder.height), display.rotation)
       .setScaleType(ViewPort.FILL_CENTER)
@@ -260,7 +260,7 @@ fun snippet_foldables_2(viewfinder: View, display: Display, preview: Preview) {
 
 
 @android.annotation.SuppressLint("UnsafeOptInUsageError", "WrongConstant")
-fun snippet_thermals_1() {
+private fun snippet_thermals_1() {
   // [START android_camerax_skill_thermals_1]
   // In CameraX: Set the hint on your Use Case
   val preview = Preview.Builder()
@@ -274,7 +274,7 @@ fun snippet_thermals_1() {
   // [END android_camerax_skill_thermals_1]
 }
 
-fun snippet_thermals_2(context: Context) {
+private fun snippet_thermals_2(context: Context) {
   // [START android_camerax_skill_thermals_2]
   val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
   powerManager.addThermalStatusListener { status ->
@@ -294,7 +294,7 @@ fun snippet_thermals_2(context: Context) {
   // [END android_camerax_skill_thermals_2]
 }
 
-suspend fun snippet_testing_1(context: Context) {
+private suspend fun snippet_testing_1(context: Context) {
   // [START android_camerax_skill_testing_1]
   // Use awaitInstance() extension function for coroutine-based provider retrieval
   val cameraProvider = ProcessCameraProvider.awaitInstance(context)
@@ -302,7 +302,7 @@ suspend fun snippet_testing_1(context: Context) {
 }
 
 // FakeImageProxy for tests
-class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
+private class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
     override fun close() {}
     override fun getCropRect(): Rect = Rect(0, 0, w, h)
     override fun setCropRect(rect: Rect?) {}
@@ -315,7 +315,7 @@ class FakeImageProxy(private val w: Int, private val h: Int) : ImageProxy {
     override fun getImage(): Image? = null
 }
 
-fun snippet_testing_2() {
+private fun snippet_testing_2() {
   // [START android_camerax_skill_testing_2]
   // Create a Fake ImageProxy for ML Testing (Fakes over Mocks)
   val fakeImage = FakeImageProxy(w = 640, h = 480)
@@ -324,13 +324,13 @@ fun snippet_testing_2() {
   // [END android_camerax_skill_testing_2]
 }
 
-fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
+private fun compressToJpeg(bitmap: Bitmap, quality: Int): ByteArray {
     val stream = java.io.ByteArrayOutputStream()
     bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
     return stream.toByteArray()
 }
 
-fun snippet_wear_os_1(context: Context, previewView: PreviewView) {
+private fun snippet_wear_os_1(context: Context, previewView: PreviewView) {
   // [START android_camerax_skill_wear_os_1]
   // Example: Sending a viewfinder frame to the watch
   val bitmap = previewView.bitmap // Capture current frame
@@ -345,14 +345,14 @@ fun snippet_wear_os_1(context: Context, previewView: PreviewView) {
   // [END android_camerax_skill_wear_os_1]
 }
 
-fun snippet_wear_os_2(context: Context, nodeId: String) {
+private fun snippet_wear_os_2(context: Context, nodeId: String) {
   // [START android_camerax_skill_wear_os_2]
   // Watch sends a trigger to the phone
   Wearable.getMessageClient(context).sendMessage(nodeId, "/camera/capture", null)
   // [END android_camerax_skill_wear_os_2]
 }
 
-fun PendingRecording.start(e: Executor, l: Consumer<VideoRecordEvent>): Any = Any()
-fun ViewPort.Builder.setRotation(r: Int): ViewPort.Builder = this
-fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
-class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)
+private fun PendingRecording.start(e: Executor, l: Consumer<VideoRecordEvent>): Any = Any()
+private fun ViewPort.Builder.setRotation(r: Int): ViewPort.Builder = this
+private fun ViewPort.getTransformationMatrix(i: Int): Matrix = Matrix()
+private class SimpleCameraEffect(targets: Int, executor: Executor, processor: SurfaceProcessor, consumer: Consumer<Throwable>) : CameraEffect(targets, executor, processor, consumer)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,6 +146,7 @@ androidx-camera-viewfinder-compose = { module = "androidx.camera.viewfinder:view
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "androidx-cameraX" }
 androidx-camera-extensions = { module = "androidx.camera:camera-extensions", version.ref = "androidx-cameraX" }
 androidx-camera-video = { module = "androidx.camera:camera-video", version.ref = "androidx-cameraX" }
+androidx-camera-effects = { module = "androidx.camera:camera-effects", version.ref = "androidx-cameraX" }
 mlkit-face-detection = { module = "com.google.mlkit:face-detection", version.ref = "mlkit-face-detection" }
 androidx-car = { module = "androidx.car.app:app", version.ref = "androidx-car"}
 androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose-latest" }
@@ -208,6 +209,7 @@ androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-view
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle-viewmodel-navigation3" }
 androidx-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
 androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
+androidx-media3-effect = { module = "androidx.media3:media3-effect", version.ref = "media3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Ui" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -138,10 +138,14 @@ androidx-appfunctions-compiler = { module = "androidx.appfunctions:appfunctions-
 androidx-appfunctions-service = { module = "androidx.appfunctions:appfunctions-service", version.ref = "androidx-appfunctions" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "androidx-cameraX" }
 androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "androidx-cameraX" }
+androidx-camera-ktx = { module = "androidx.camera:camera-ktx", version.ref = "androidx-cameraX" }
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "androidx-cameraX" }
 androidx-camera-compose = { module = "androidx.camera:camera-compose", version.ref = "androidx-cameraX" }
 androidx-camera-viewfinder-compose = { module = "androidx.camera.viewfinder:viewfinder-compose", version.ref = "androidx-cameraX" }
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "androidx-cameraX" }
+androidx-camera-extensions = { module = "androidx.camera:camera-extensions", version.ref = "androidx-cameraX" }
+androidx-camera-video = { module = "androidx.camera:camera-video", version.ref = "androidx-cameraX" }
+mlkit-face-detection = "com.google.mlkit:face-detection:16.1.7"
 androidx-car = { module = "androidx.car.app:app", version.ref = "androidx-car"}
 androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose-latest" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,7 @@ ksp = "2.3.7"
 ktlint = "1.5.0"
 lifecycleService = "2.10.0"
 maps-compose = "8.3.0"
+mlkit-face-detection = "16.1.7"
 material = "1.14.0-beta01"
 material3-adaptive = "1.2.0"
 material3-adaptive-navigation-suite = "1.4.0"
@@ -145,7 +146,7 @@ androidx-camera-viewfinder-compose = { module = "androidx.camera.viewfinder:view
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "androidx-cameraX" }
 androidx-camera-extensions = { module = "androidx.camera:camera-extensions", version.ref = "androidx-cameraX" }
 androidx-camera-video = { module = "androidx.camera:camera-video", version.ref = "androidx-cameraX" }
-mlkit-face-detection = "com.google.mlkit:face-detection:16.1.7"
+mlkit-face-detection = { module = "com.google.mlkit:face-detection", version.ref = "mlkit-face-detection" }
 androidx-car = { module = "androidx.car.app:app", version.ref = "androidx-car"}
 androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose-latest" }
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }


### PR DESCRIPTION
These snippets will be used in conjunction with @madebymozart's migration snippets (https://github.com/android/snippets/pull/943) into a single CameraX skill (per the skill team's recommendation). 