### PR TITLE
chore(wear): bump targetSdk to 37

### DIFF
--- a/watchface/build.gradle.kts
+++ b/watchface/build.gradle.kts
@@ -19,12 +19,12 @@ plugins {
 
 android {
     namespace = "com.example.simpledigital"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.simpledigital"
         minSdk = 36
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0.0"
     }

--- a/wearcompanion/build.gradle.kts
+++ b/wearcompanion/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.example.wear.snippets"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.wear.snippets"
         minSdk = 28
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
Aligns the `wearcompanion` and `watchface` modules with target SDK 37, matching the main `wear` module and the shared configuration in `libs.versions.toml`.

Specifically:
- Bumps `compileSdk` and `targetSdk` from 36 to 37 in `wearcompanion/build.gradle.kts`.
- Bumps `compileSdk` and `targetSdk` from 36 to 37 in `watchface/build.gradle.kts`.

Verified that both projects configure and compile successfully after the bump.