### PR TITLE
Update XR snippets for latest release of the Jetpack XR SDK

### DIFF
--- a/xr/build.gradle.kts
+++ b/xr/build.gradle.kts
@@ -135,10 +135,16 @@ dependencies {
 }
 
 fun Provider<MinimalExternalModuleDependency>.toSnapshotDependency(): Provider<MinimalExternalModuleDependency> =
-    this.map {
-        it.copy().apply {
-            version {
-                strictly("1.0.0-SNAPSHOT")
+    this.map { dependency ->
+        // Don't update the Projected dependency until the emulator supports the latest APIs
+        // b/544045508
+        if (dependency.module.group == "androidx.xr.projected") {
+            dependency
+        } else {
+            dependency.copy().apply {
+                version {
+                    strictly("1.0.0-SNAPSHOT")
+                }
             }
         }
     }

--- a/xr/libs.versions.toml
+++ b/xr/libs.versions.toml
@@ -1,10 +1,11 @@
 [versions]
-androidx-xr-arcore = "1.0.0-beta01"
-androidx-xr-arcore-play-services = "1.0.0-beta01"
-androidx-xr-compose = "1.0.0-alpha16"
-androidx-xr-glimmer = "1.0.0-alpha15"
-androidx-xr-projected = "1.0.0-alpha10"
-androidx-xr-scenecore = "1.0.0-beta01"
+androidx-xr-arcore = "1.0.0-beta02"
+androidx-xr-arcore-play-services = "1.0.0-beta02"
+androidx-xr-compose = "1.0.0-alpha17"
+androidx-xr-glimmer = "1.0.0-alpha17"
+# Keep the Projected dependency on alpha10 until the emulator supports the latest APIs - b/544045508
+androidx-xr-projected = "1.0.0-alphqa10"
+androidx-xr-scenecore = "1.0.0-beta02"
 
 [libraries]
 androidx-xr-arcore = { module = "androidx.xr.arcore:arcore", version.ref = "androidx-xr-arcore" }

--- a/xr/src/main/java/com/example/xr/compose/Orbiter.kt
+++ b/xr/src/main/java/com/example/xr/compose/Orbiter.kt
@@ -37,7 +37,8 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.xr.compose.spatial.Orbiter
-import androidx.xr.compose.spatial.OrbiterAnchorPoint
+import androidx.xr.compose.spatial.OrbiterAlignment
+import androidx.xr.compose.spatial.OrbiterEdgeOffsetType
 import androidx.xr.compose.spatial.Subspace
 import androidx.xr.compose.subspace.SpatialPanel
 import androidx.xr.compose.subspace.SpatialRow
@@ -72,8 +73,10 @@ private fun OrbiterExampleSubspace() {
 @Composable
 fun OrbiterExample() {
     Orbiter(
-        anchorPoint = OrbiterAnchorPoint.Bottom,
-        offset = DpVolumeOffset(y = 96.dp),
+        alignment = OrbiterAlignment.BottomCenter(
+            edgeOffsetType = OrbiterEdgeOffsetType.OuterEdge,
+            offset = DpVolumeOffset(y = 96.dp)
+        ),
     ) {
         Surface(Modifier.clip(CircleShape)) {
             Row(
@@ -101,8 +104,10 @@ fun OrbiterAnchoringExample() {
     Subspace {
         SpatialRow {
             Orbiter(
-                anchorPoint = OrbiterAnchorPoint.Top,
-                offset = DpVolumeOffset(y = 8.dp),
+                alignment = OrbiterAlignment.TopCenter(
+                    edgeOffsetType = OrbiterEdgeOffsetType.OuterEdge,
+                    offset = DpVolumeOffset(y = 8.dp)
+                ),
                 shape = SpatialRoundedCornerShape(size = CornerSize(50))
             ) {
                 Text(
@@ -149,8 +154,10 @@ private fun Ui2DToOribiter() {
 
     // New XR differentiated approach
     Orbiter(
-        anchorPoint = OrbiterAnchorPoint.StartTop,
-        offset = DpVolumeOffset(x = dimensionResource(R.dimen.start_orbiter_padding)),
+        alignment = OrbiterAlignment.TopStart(
+            edgeOffsetType = OrbiterEdgeOffsetType.OuterEdge,
+            offset = DpVolumeOffset(x = dimensionResource(R.dimen.start_orbiter_padding))
+        )
     ) {
         NavigationRail()
     }

--- a/xr/src/main/java/com/example/xr/compose/SpatialGltfModel.kt
+++ b/xr/src/main/java/com/example/xr/compose/SpatialGltfModel.kt
@@ -16,16 +16,14 @@
 
 package com.example.xr.compose
 
-import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.xr.compose.platform.LocalSession
-import androidx.xr.compose.subspace.ExperimentalSpatialGltfAnimationApi
+import androidx.xr.compose.subspace.ExperimentalSpatialGltfModelApi
 import androidx.xr.compose.subspace.SpatialGltfModel
 import androidx.xr.compose.subspace.SpatialGltfModelSource
 import androidx.xr.compose.subspace.layout.SubspaceModifier
@@ -39,7 +37,7 @@ import androidx.xr.scenecore.Texture
 import java.nio.file.Paths
 import kotlin.io.path.Path
 
-@OptIn(ExperimentalSpatialGltfAnimationApi::class)
+@OptIn(ExperimentalSpatialGltfModelApi::class)
 @Composable
 fun SpatialGltfModelExample(){
     val xrSession = checkNotNull(LocalSession.current)
@@ -132,23 +130,6 @@ fun SpatialGltfModelExample(){
         )
     }
     // [END androidxr_compose_SpatialGltfModelTexture]
-
-    // [START androidxr_compose_SpatialGltfModelAnimation]
-    val animation = modelState.getAnimations().find { it.name == "Walk" }
-
-    animation?.animationState?.let { state ->
-        LaunchedEffect(state) {
-            Log.i("SpatialGltfModelAnimationSample", "Animation State: $state")
-        }
-    }
-
-    DisposableEffect(animation) {
-        animation?.loop()
-        onDispose {
-            animation?.stop()
-        }
-    }
-    // [END androidxr_compose_SpatialGltfModelAnimation]
 
     // [START androidxr_compose_SpatialGltfModelLoad]
     SpatialGltfModel(state = modelState, modifier = SubspaceModifier)


### PR DESCRIPTION
- Projected: Don't update the XR Projected snippets until the XR emulator supports the new permission APIs
- Orbiter: Migrate from deprecated OrbiterAnchorPoint to OrbiterAlignment
- SpatialGltfModel: Remove experimental Compose glTF animation API usages