### PR TITLE
chore(wear): use 1.7.0-beta01 in wear:snapshot

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,7 +23,6 @@ dependencyResolutionManagement {
                 includeGroup("com.github.xgouchet")
             }
         }
-        maven { url = uri("https://androidx.dev/snapshots/latest/artifacts/repository/") }
         google()
         mavenCentral()
     }

--- a/wear/snapshot/build.gradle.kts
+++ b/wear/snapshot/build.gradle.kts
@@ -35,9 +35,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.wear.tooling.preview)
 
-    // Snapshot dependencies required for OneHandedGestures; expected to go away in the first 1.7.0 beta release.
-    implementation("androidx.wear.compose:compose-material3:1.7.0-SNAPSHOT")
-    implementation("androidx.compose.foundation:foundation:1.7.0-SNAPSHOT")
+    implementation("androidx.wear.compose:compose-material3:1.7.0-beta01")
+    implementation("androidx.wear.compose:compose-foundation:1.7.0-beta01")
     implementation(libs.wear.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(libs.androidx.compose.material.iconsExtended)

--- a/wear/snapshot/src/main/java/com/example/wear/snippets/m3/gestures/OneHandedGestures.kt
+++ b/wear/snapshot/src/main/java/com/example/wear/snippets/m3/gestures/OneHandedGestures.kt
@@ -16,10 +16,6 @@
 
 package com.example.wear.snippets.m3.gestures
 
-/*
- * NOTE: One-Handed Gesture APIs require Wear Compose Material 3 1.7.0-SNAPSHOT (expected to go away in the first 1.7.0 beta release).
- * Published alpha releases up to 1.7.0-alpha07 used older API names (GestureAction/GesturePriority) and will not compile with these snippets.
- */
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.fillMaxSize


### PR DESCRIPTION
### Summary
Replaces the `1.7.0-SNAPSHOT` dependencies in `:wear:snapshot` with the published `1.7.0-beta01` release and removes the snapshot repository.

### Changes
- Updated `wear/snapshot/build.gradle.kts` to depend on `androidx.wear.compose:compose-material3:1.7.0-beta01` and `androidx.wear.compose:compose-foundation:1.7.0-beta01`.
- Removed the `androidx.dev/snapshots` Maven repository from `settings.gradle.kts` since `1.7.0-beta01` is hosted on Google Maven (`google()`).
- Removed outdated SNAPSHOT comments from `OneHandedGestures.kt`.

### Verification
- `./gradlew :wear:snapshot:spotlessApply :wear:spotlessApply`
- `./gradlew :wear:snapshot:lintDebug :wear:lintDebug`
- `./gradlew :wear:snapshot:assembleDebug :wear:assembleDebug`
