### PR TITLE
Fix extra parenthesis in Navigation3 metadata snippet

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/navigation3/metadata/MetadataSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/navigation3/metadata/MetadataSnippets.kt
@@ -50,7 +50,7 @@ fun dslEntryProvider() {
         // [START android_compose_navigation3_metadata_2]
         entry<Home>(metadata = mapOf("key" to "value")) { /* ... */ }
         entry<Conversation>(metadata = { key: Conversation ->
-            mapOf("key" to "value: ${key.id})")
+            mapOf("key" to "value: ${key.id}")
         }) { /* ... */ }
         // [END android_compose_navigation3_metadata_2]
     }


### PR DESCRIPTION
Fixes a small typo in the Navigation3 metadata snippet.

The snippet demonstrates creating metadata from the entry key, but the current string value includes an extra closing parenthesis:

```kotlin
mapOf("key" to "value: ${key.id})")
```

This makes the metadata value include an unintended trailing `)`, such as `value: 123)`. This PR removes the extra parenthesis:

```kotlin
mapOf("key" to "value: ${key.id}")
```