### PR TITLE
Add permission security snippets for permission skill

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidx-corektx = "1.19.0"
 androidx-corepip = "1.0.0-alpha02"
 androidx-credentials = "1.7.0-alpha03"
 androidx-credentials-play-services-auth = "1.7.0-alpha03"
+androidx-security-app-authenticator = "1.0.0-alpha02"
 androidx-emoji2-views = "1.6.0"
 androidx-fragment = "1.8.9"
 androidx-glance-appwidget = "1.3.0-alpha02"
@@ -250,6 +251,7 @@ androidx-room3-runtime = { module = "androidx.room3:room3-runtime", version.ref 
 androidx-room3-rxjava3 = { module = "androidx.room3:room3-rxjava3", version.ref = "room3" }
 androidx-room3-sqlite-wrapper = { module = "androidx.room3:room3-sqlite-wrapper", version.ref = "room3" }
 androidx-room3-testing = { module = "androidx.room3:room3-testing", version.ref = "room3" }
+androidx-security-app-authenticator = { module = "androidx.security:security-app-authenticator", version.ref = "androidx-security-app-authenticator" }
 androidx-sqlite-async = { module = "androidx.sqlite:sqlite-async", version.ref = "sqlite" }
 androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 androidx-sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }

--- a/security/build.gradle.kts
+++ b/security/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.androidx.activity.compose) // For ComponentActivity
+    implementation(libs.androidx.security.app.authenticator)
 }

--- a/security/src/main/AndroidManifest.xml
+++ b/security/src/main/AndroidManifest.xml
@@ -29,6 +29,39 @@
         android:name="com.example.snippets.permission.WRITE_DATA"
         android:protectionLevel="signature" />
 
+    <!--[START android_security_custom_permission_signature_manifest]-->
+    <permission
+        android:name="com.example.snippets.permission.ACCESS_SECURE_API"
+        android:protectionLevel="signature" />
+    <!--[END android_security_custom_permission_signature_manifest]-->
+
+    <!--[START android_security_custom_permission_known_signer_manifest]-->
+    <permission
+        android:name="com.example.snippets.permission.PARTNER_API"
+        android:protectionLevel="signature|knownSigner"
+        android:knownCerts="@array/trusted_partner_certs" />
+    <!--[END android_security_custom_permission_known_signer_manifest]-->
+
+    <!--[START android_security_content_provider_read_write_manifest]-->
+    <!-- Partner read permission (OS-validated via knownSigner) -->
+    <permission
+        android:name="com.example.snippets.permission.READ_DATA_PARTNER"
+        android:protectionLevel="signature|knownSigner"
+        android:knownCerts="@array/trusted_partner_certs" />
+
+    <!-- Owner-only write permission -->
+    <permission
+        android:name="com.example.snippets.permission.WRITE_DATA_OWNER"
+        android:protectionLevel="signature" />
+    <!--[END android_security_content_provider_read_write_manifest]-->
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <application>
         <!--[START android_security_custom_permission_activity_manifest]-->
         <activity
@@ -51,6 +84,56 @@
             android:writePermission="com.example.snippets.permission.WRITE_DATA"
             android:grantUriPermissions="false" />
         <!--[END android_security_contentprovider_manifest]-->
+
+        <activity
+            android:name=".permissions.CameraActivity"
+            android:exported="false" />
+
+        <!--[START android_security_custom_permission_service_manifest]-->
+        <service
+            android:name=".permissions.SecureDataService"
+            android:exported="true"
+            android:permission="com.example.snippets.permission.ACCESS_SECURE_API">
+            <intent-filter>
+                <action android:name="com.example.snippets.ACTION_GET_DATA" />
+            </intent-filter>
+        </service>
+        <!--[END android_security_custom_permission_service_manifest]-->
+
+        <!--[START android_security_known_signer_service_manifest]-->
+        <service
+            android:name=".permissions.PartnerDataService"
+            android:exported="true"
+            android:permission="com.example.snippets.permission.PARTNER_API">
+            <intent-filter>
+                <action android:name="com.example.snippets.ACTION_GET_PARTNER_DATA" />
+            </intent-filter>
+        </service>
+        <!--[END android_security_known_signer_service_manifest]-->
+
+        <!--[START android_security_protected_broadcast_receiver_manifest]-->
+        <receiver
+            android:name=".permissions.MyProtectedReceiver"
+            android:exported="true"
+            android:permission="com.example.snippets.permission.ACCESS_SECURE_API">
+            <intent-filter>
+                <action android:name="com.example.snippets.ACTION_SECRET_UPDATE" />
+            </intent-filter>
+        </receiver>
+        <!--[END android_security_protected_broadcast_receiver_manifest]-->
+
+        <service
+            android:name=".permissions.FineGrainedBoundService"
+            android:exported="false" />
+
+        <!--[START android_security_provider_read_write_manifest]-->
+        <provider
+            android:name=".permissions.PartnerSecureDataProvider"
+            android:authorities="com.example.snippets.partnerprovider"
+            android:exported="true"
+            android:readPermission="com.example.snippets.permission.READ_DATA_PARTNER"
+            android:writePermission="com.example.snippets.permission.WRITE_DATA_OWNER" />
+        <!--[END android_security_provider_read_write_manifest]-->
     </application>
 
 </manifest>

--- a/security/src/main/AndroidManifest.xml
+++ b/security/src/main/AndroidManifest.xml
@@ -61,6 +61,7 @@
         android:required="false" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <application>
         <!--[START android_security_custom_permission_activity_manifest]-->
@@ -87,6 +88,12 @@
 
         <activity
             android:name=".permissions.CameraActivity"
+            android:exported="false" />
+        <activity
+            android:name=".permissions.LocationPermissionActivity"
+            android:exported="false" />
+        <activity
+            android:name=".permissions.MediaPickerActivity"
             android:exported="false" />
 
         <!--[START android_security_custom_permission_service_manifest]-->

--- a/security/src/main/java/com/example/snippets/security/permissions/CallerVerifier.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/CallerVerifier.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.content.Context
+import androidx.security.app.authenticator.AppAuthenticator
+import com.example.snippets.security.R
+
+// [START android_security_caller_verifier_app_authenticator]
+class CallerVerifier(private val context: Context) {
+    private val appAuthenticator: AppAuthenticator by lazy {
+        AppAuthenticator.createFromResource(context, R.xml.allowed_peers)
+    }
+
+    /**
+     * Verifies the caller's identity.
+     *
+     * @param callingPackage The package name of the caller.
+     * @throws SecurityException If the caller is not authorized.
+     */
+    fun enforceCaller(callingPackage: String) {
+        try {
+            appAuthenticator.enforceAppIdentity(callingPackage)
+        } catch (e: SecurityException) {
+            throw SecurityException("Caller $callingPackage is not authorized", e)
+        }
+    }
+}
+// [END android_security_caller_verifier_app_authenticator]

--- a/security/src/main/java/com/example/snippets/security/permissions/FineGrainedBoundService.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/FineGrainedBoundService.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+
+// Stub interface representing AIDL generated interface
+interface IMyService {
+    fun getData(): String
+    fun modifyData(newData: String)
+}
+
+// [START android_security_service_enforce_calling_permission]
+class FineGrainedBoundService : Service() {
+
+    private val binder = object : Binder(), IMyService {
+        override fun getData(): String {
+            // Enforce read permission on the caller
+            enforceCallingPermission(
+                "com.example.snippets.permission.READ_DATA",
+                "Caller does not have READ_DATA permission"
+            )
+            return "Sensitive data from service"
+        }
+
+        override fun modifyData(newData: String) {
+            // Enforce write permission on the caller
+            enforceCallingPermission(
+                "com.example.snippets.permission.WRITE_DATA",
+                "Caller does not have WRITE_DATA permission"
+            )
+            // Perform modification
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        return binder
+    }
+}
+// [END android_security_service_enforce_calling_permission]

--- a/security/src/main/java/com/example/snippets/security/permissions/LocationPermissionSnippets.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/LocationPermissionSnippets.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.Manifest
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+
+// [START android_security_sequential_location_permission]
+class LocationPermissionActivity : ComponentActivity() {
+
+    // Step 1: Register launcher for ACCESS_FINE_LOCATION and ACCESS_COARSE_LOCATION
+    private val foregroundLocationLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            val fineLocationGranted =
+                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false)
+            val coarseLocationGranted =
+                permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false)
+
+            if (fineLocationGranted || coarseLocationGranted) {
+                // Foreground location access granted. Now request background location in a distinct step.
+                requestBackgroundLocation()
+            } else {
+                onForegroundLocationDenied()
+            }
+        }
+
+    // Step 2: Register a separate launcher for ACCESS_BACKGROUND_LOCATION
+    private val backgroundLocationLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                onBackgroundLocationGranted()
+            } else {
+                onBackgroundLocationDenied()
+            }
+        }
+
+    // Request foreground permissions first
+    fun requestForegroundLocation() {
+        foregroundLocationLauncher.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+
+    // Request background location only after foreground permissions have been granted
+    fun requestBackgroundLocation() {
+        backgroundLocationLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+    }
+
+    private fun onForegroundLocationDenied() {
+        // Handle foreground location denial
+    }
+
+    private fun onBackgroundLocationGranted() {
+        // Start background location updates
+    }
+
+    private fun onBackgroundLocationDenied() {
+        // Handle background location denial; proceed with foreground-only features
+    }
+}
+// [END android_security_sequential_location_permission]

--- a/security/src/main/java/com/example/snippets/security/permissions/MediaPickerSnippets.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/MediaPickerSnippets.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+
+// [START android_security_photo_picker_request]
+class MediaPickerActivity : ComponentActivity() {
+
+    // Registers a photo picker activity launcher in single-select mode.
+    // The photo picker provides safe, direct access to media items without requiring
+    // READ_EXTERNAL_STORAGE or READ_MEDIA_IMAGES permissions.
+    private val launcher =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri: Uri? ->
+            if (uri != null) {
+                // Access the media directly using the returned URI without storage permissions.
+                handleSelectedImage(uri)
+            } else {
+                handleNoImageSelected()
+            }
+        }
+
+    fun selectPhoto() {
+        launcher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+    }
+
+    private fun handleSelectedImage(uri: Uri) {
+        // Direct URI access without requesting storage permissions
+    }
+
+    private fun handleNoImageSelected() {
+        // Picker was cancelled or no photo was selected
+    }
+}
+// [END android_security_photo_picker_request]

--- a/security/src/main/java/com/example/snippets/security/permissions/PermissionComponentStubs.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/PermissionComponentStubs.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.app.Service
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Intent
+import android.database.Cursor
+import android.net.Uri
+import android.os.IBinder
+
+class SecureDataService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+}
+
+class PartnerDataService : Service() {
+    override fun onBind(intent: Intent?): IBinder? = null
+}
+
+class PartnerSecureDataProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<String>?,
+        selection: String?,
+        selectionArgs: Array<String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<String>?
+    ): Int = 0
+}

--- a/security/src/main/java/com/example/snippets/security/permissions/PermissionErrorHandling.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/PermissionErrorHandling.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.os.Binder
+import android.os.Process
+import android.util.Base64
+import android.util.Log
+
+class PermissionErrorHandling(private val context: Context) {
+
+    // [START android_security_permission_error_handling]
+    fun safeLocationAccess(locationManager: LocationManager) {
+        val pm = context.packageManager
+        try {
+            @Suppress("DEPRECATION")
+            val info = pm.getPackageInfo("com.unknown.app", PackageManager.GET_SIGNATURES)
+        } catch (e: PackageManager.NameNotFoundException) {
+            Log.e("PERMISSION_ERROR", "Requested package information is not installed.", e)
+            // Abort actions calling the target package
+        }
+
+        try {
+            // Calling API requiring ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION
+            val lastLocation = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+            if (lastLocation != null) {
+                displayLocationData(lastLocation)
+            }
+        } catch (e: SecurityException) {
+            Log.w("PERMISSION_DENIED", "Attempted to access location without GPS permission", e)
+            // Fallback logic: Use a default location or guide user to enter location manually
+            useDefaultLocation()
+        }
+    }
+    // [END android_security_permission_error_handling]
+
+    // [START android_security_caller_signature_verification]
+    fun verifyCallerIdentity(trustedSha256: String) {
+        val callingUid = Binder.getCallingUid()
+        if (callingUid == Process.myUid()) {
+            return
+        }
+
+        val pm = context.packageManager
+        val packages = pm.getPackagesForUid(callingUid)
+        if (packages.isNullOrEmpty()) {
+            throw SecurityException("Unknown caller UID: $callingUid")
+        }
+
+        val callingPackage = packages[0]
+        val trustedSha256Raw = Base64.decode(trustedSha256, Base64.DEFAULT)
+        // API 28+ handles signing key lineage and avoids manual cert parsing
+        val isTrusted = pm.hasSigningCertificate(
+            callingPackage,
+            trustedSha256Raw,
+            PackageManager.CERT_INPUT_SHA256
+        )
+
+        if (!isTrusted) {
+            throw SecurityException("Caller signature verification failed for $callingPackage")
+        }
+    }
+    // [END android_security_caller_signature_verification]
+
+    private fun displayLocationData(location: Location) {}
+    private fun useDefaultLocation() {}
+}

--- a/security/src/main/java/com/example/snippets/security/permissions/ProtectedBroadcastSnippets.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/ProtectedBroadcastSnippets.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.app.BroadcastOptions
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+
+// [START android_security_protected_broadcast_send]
+fun sendProtectedBroadcast(context: Context) {
+    val intent = Intent("com.example.snippets.ACTION_SECRET_UPDATE")
+    // Enforce permission requirements during broadcast dispatch
+    context.sendBroadcast(intent, "com.example.snippets.permission.ACCESS_SECURE_API")
+}
+// [END android_security_protected_broadcast_send]
+
+// [START android_security_broadcast_sender_identity]
+@Suppress("ObsoleteSdkInt")
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+fun sendBroadcastWithIdentity(context: Context) {
+    val intent = Intent("com.example.snippets.ACTION_SECRET_UPDATE")
+
+    // Opt-in to sharing sender identity
+    val options = BroadcastOptions.makeBasic().apply {
+        setShareIdentityEnabled(true)
+    }
+
+    context.sendBroadcast(
+        intent,
+        "com.example.snippets.permission.ACCESS_SECURE_API",
+        options.toBundle()
+    )
+}
+// [END android_security_broadcast_sender_identity]
+
+// [START android_security_broadcast_receiver_verify_identity]
+class MyProtectedReceiver : BroadcastReceiver() {
+    @Suppress("ObsoleteSdkInt")
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "com.example.snippets.ACTION_SECRET_UPDATE") {
+            // Retrieve the sender's package name on Android 14+
+            val senderPackage = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                sentFromPackage
+            } else {
+                null
+            }
+
+            if (senderPackage != null) {
+                try {
+                    // Verify the sender's identity using AppAuthenticator
+                    CallerVerifier(context).enforceCaller(senderPackage)
+                    processUpdate(intent)
+                } catch (e: SecurityException) {
+                    Log.w("SECURITY_ALERT", "Untrusted broadcast sender: $senderPackage", e)
+                }
+            } else {
+                Log.w("SECURITY_ALERT", "Broadcast received without sender identity")
+            }
+        }
+    }
+
+    private fun processUpdate(intent: Intent) {}
+}
+// [END android_security_broadcast_receiver_verify_identity]

--- a/security/src/main/java/com/example/snippets/security/permissions/RuntimePermissionsActivity.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/RuntimePermissionsActivity.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
+// [START android_security_runtime_permission_request]
+class CameraActivity : ComponentActivity() {
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                startCameraPreview()
+            } else {
+                showPermissionDeniedFeedback()
+            }
+        }
+
+    fun checkAndLaunchCamera(permission: String) {
+        when {
+            ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED -> {
+                startCameraPreview()
+            }
+            // Handle the case where the user denied the permission before.
+            shouldShowRequestPermissionRationale(permission) -> {
+                showPermissionRationaleAndRetry(permission)
+            }
+            else -> {
+                // Request the permission for the first time.
+                requestPermissionLauncher.launch(permission)
+            }
+        }
+    }
+
+    private fun showPermissionRationaleAndRetry(permission: String) {
+        // UI logic to explain why the permission is needed, then re-trigger launch:
+        // requestPermissionLauncher.launch(permission)
+    }
+
+    private fun startCameraPreview() { /* Camera preview initialization logic */ }
+    private fun showPermissionDeniedFeedback() { /* UI warning indicating permission is required */ }
+}
+// [END android_security_runtime_permission_request]

--- a/security/src/main/java/com/example/snippets/security/permissions/RuntimePermissionsActivity.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/RuntimePermissionsActivity.kt
@@ -16,7 +16,11 @@
 
 package com.example.snippets.security.permissions
 
+import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -24,12 +28,21 @@ import androidx.core.content.ContextCompat
 // [START android_security_runtime_permission_request]
 class CameraActivity : ComponentActivity() {
 
+    private val permission = Manifest.permission.CAMERA
+
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
             if (isGranted) {
                 startCameraPreview()
             } else {
-                showPermissionDeniedFeedback()
+                if (!shouldShowRequestPermissionRationale(permission)) {
+                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                        data = Uri.fromParts("package", packageName, null)
+                    }
+                    startActivity(intent)
+                } else {
+                    showPermissionDeniedFeedback()
+                }
             }
         }
 

--- a/security/src/main/java/com/example/snippets/security/permissions/UriPermissionSnippets.kt
+++ b/security/src/main/java/com/example/snippets/security/permissions/UriPermissionSnippets.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.security.permissions
+
+import android.content.Context
+import android.content.Intent
+import android.content.UriPermission
+import android.net.Uri
+
+// [START android_security_uri_permission_management]
+fun grantScopedUriAccess(context: Context, targetPackage: String, uri: Uri) {
+    context.grantUriPermission(
+        targetPackage,
+        uri,
+        Intent.FLAG_GRANT_READ_URI_PERMISSION
+    )
+}
+
+fun getActivePersistedPermissions(context: Context): List<UriPermission> {
+    return context.contentResolver.persistedUriPermissions
+}
+
+fun revokeScopedUriAccess(context: Context, uri: Uri) {
+    context.revokeUriPermission(
+        uri,
+        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    )
+}
+// [END android_security_uri_permission_management]

--- a/security/src/main/res/values/security_certs.xml
+++ b/security/src/main/res/values/security_certs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2026 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- [START android_security_known_signer_certs_xml] -->
+    <!-- SHA-256 fingerprints of trusted partner certificates (lowercase, no colons) -->
+    <string-array name="trusted_partner_certs" tools:ignore="Typos">
+        <item>103938ee4537e59e8ee792f654504fb8346fc6b346d0bbc4415fc339fcfc8ec1</item>
+    </string-array>
+    <!-- [END android_security_known_signer_certs_xml] -->
+</resources>

--- a/security/src/main/res/xml/allowed_peers.xml
+++ b/security/src/main/res/xml/allowed_peers.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2026 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<app-authenticator>
+    <!-- [START android_security_allowed_peers_xml] -->
+    <permission name="com.example.snippets.permission.ACCESS_PARTNER_API">
+        <!-- SHA-256 fingerprint of the partner's certificate (uppercase, no colons) -->
+        <package name="com.example.partner">
+            <cert-digest>A1B2C3D4E5F60708090A0B0C0D0E0F1011121314151617181920212223242526</cert-digest>
+        </package>
+    </permission>
+    <!-- [END android_security_allowed_peers_xml] -->
+</app-authenticator>


### PR DESCRIPTION
Adds code snippets and XML resources for the `security` module demonstrating Android permission security best practices and caller identity validation. These snippets ground the `android-permission-security` skill in tested, linted, and compiled code.

Changes made:
- **Custom Signature Permissions:** Demonstrates `signature` protection levels for private inter-app communication in `AndroidManifest.xml`.
- **Known Signer Permissions (API 31+):** Adds `knownSigner` permission configuration with certificate digest verification in `security_certs.xml` and `AndroidManifest.xml`.
- **Caller Validation (`AppAuthenticator`):** Implements `CallerVerifier.kt` using Jetpack `androidx.security:security-app-authenticator` configured via `allowed_peers.xml`.
- **Runtime Permission Workflow:** Adds `RuntimePermissionsActivity.kt` implementing modern `ActivityResultContracts.RequestPermission` and educational rationale checks (`shouldShowRequestPermissionRationale`).
- **Protected Broadcasts:** Demonstrates permission-guarded broadcast dispatch, Android 14+ sender identity opt-in (`BroadcastOptions.setShareIdentityEnabled`), and receiver verification in `ProtectedBroadcastSnippets.kt`.
- **Binder IPC Method Checks:** Implements `FineGrainedBoundService.kt` using `enforceCallingPermission` for method-level read/write permission segregation.
- **Content Provider Protection:** Configures distinct `readPermission` (`knownSigner`) and `writePermission` (`signature`) in `AndroidManifest.xml`.
- **Error Handling & Signature Verification:** Implements `PermissionErrorHandling.kt` demonstrating `SecurityException` handling and UID certificate checks via `PackageManager.hasSigningCertificate`.