### PR TITLE
feat(wear): add widget preview snippets

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ firebase-bom = "34.17.0"
 firebase-ondevice = "16.0.0-beta03"
 fragment-testing = "1.9.0"
 genaiSchemaCompiler = "1.0.0-alpha1"
-glance-wear = "1.0.0-alpha12"
+glance-wear = "1.0.0-alpha14"
 glide = "1.0.0-beta10"
 google-ar-core = "1.54.0"
 google-maps = "20.0.0"
@@ -208,6 +208,7 @@ androidx-glance-material3 = { module = "androidx.glance:glance-material3", versi
 androidx-glance-testing = { module = "androidx.glance:glance-testing", version.ref = "androidx-glance-appwidget" }
 androidx-glance-wear = { module = "androidx.glance.wear:wear", version.ref = "glance-wear" }
 androidx-glance-wear-core = { module = "androidx.glance.wear:wear-core", version.ref = "glance-wear" }
+androidx-glance-wear-tooling-preview = { module = "androidx.glance.wear:wear-tooling-preview", version.ref = "glance-wear" }
 androidx-graphics-shapes = "androidx.graphics:graphics-shapes:1.1.0"
 androidx-health-connect = { module = "androidx.health.connect:connect-client", version.ref = "health-connect" }
 androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHiltNavigationCompose" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(libs.androidx.compose.remote.core)
     implementation(libs.androidx.glance.wear)
     implementation(libs.androidx.glance.wear.core)
+    implementation(libs.androidx.glance.wear.tooling.preview)
     implementation(libs.androidx.wear.compose.remote.material3)
     debugImplementation(libs.androidx.compose.remote.tooling.preview)
 

--- a/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
+++ b/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
@@ -31,7 +31,6 @@ import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -116,9 +115,8 @@ fun ModularWidgetContent() {
 fun HelloWidgetPreview(
     @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams,
 ) {
-    val widget = remember { HelloWidget() }
     WearWidgetPreview(
-        widget = widget,
+        widget = HelloWidget(),
         params = params,
     )
 }
@@ -149,7 +147,7 @@ fun HelloWidgetCatalogPreview(
     @PreviewParameter(RectangularLargeWidgetPreviewParams::class) params: WearWidgetParams,
 ) {
     WearWidgetPreview(
-        widget = remember { HelloWidget() },
+        widget = HelloWidget(),
         params = params,
     )
 }

--- a/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
+++ b/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
@@ -18,26 +18,39 @@ package com.example.wear.snippets.widget
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.compose.remote.creation.compose.action.Action
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
-import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.glance.wear.AssociateWithGlanceWearWidget
 import androidx.glance.wear.GlanceWearWidget
 import androidx.glance.wear.GlanceWearWidgetService
+import androidx.glance.wear.WearWidgetBrush
 import androidx.glance.wear.WearWidgetData
 import androidx.glance.wear.WearWidgetDocument
-import androidx.glance.wear.WearWidgetBrush
 import androidx.glance.wear.color
 import androidx.glance.wear.core.WearWidgetParams
+import androidx.glance.wear.tooling.preview.RectangularLargeWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.RoundAllWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.SquircleAllWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.WearWidgetPreview
+import androidx.wear.compose.remote.material3.RemoteCard
 
 // [START android_wear_widget_service]
+@AssociateWithGlanceWearWidget(HelloWidget::class)
 class HelloWidgetService : GlanceWearWidgetService() {
     override val widget: GlanceWearWidget = HelloWidget()
 }
@@ -49,7 +62,9 @@ class HelloWidget : GlanceWearWidget() {
         context: Context,
         params: WearWidgetParams,
     ): WearWidgetData {
-        return WearWidgetDocument(background = WearWidgetBrush.color(Color.Blue.rc)) {
+        return WearWidgetDocument(
+            background = WearWidgetBrush.color(Color.Blue.rc),
+        ) {
             HelloWidgetContent()
         }
     }
@@ -57,7 +72,8 @@ class HelloWidget : GlanceWearWidget() {
 // [END android_wear_widget_glance]
 
 // [START android_wear_widget_content]
-@RemoteComposable @Composable
+@RemoteComposable
+@Composable
 fun HelloWidgetContent() {
     RemoteBox(
         modifier = RemoteModifier.fillMaxSize(),
@@ -65,8 +81,76 @@ fun HelloWidgetContent() {
     ) {
         RemoteText(
             text = "Hello World".rs,
-            color = Color.White.rc
+            color = Color.White.rc,
         )
     }
 }
 // [END android_wear_widget_content]
+
+// [START android_wear_widget_modular_content]
+@RemoteComposable
+@Composable
+fun ModularWidgetContent() {
+    // Layer 2: Root container occupies full bounds without custom background clipping
+    RemoteBox(
+        modifier = RemoteModifier.fillMaxSize(),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        // Layer 3: Internal modular cards/buttons sit on top of the document canvas
+        RemoteCard(
+            onClick = Action.Empty,
+            modifier = RemoteModifier.padding(16.rdp),
+        ) {
+            RemoteText(
+                text = "Modular Card".rs,
+                color = Color.White.rc,
+            )
+        }
+    }
+}
+// [END android_wear_widget_modular_content]
+
+// [START android_wear_widget_preview]
+@Preview
+@Composable
+fun HelloWidgetPreview(
+    @PreviewParameter(SquircleAllWidgetPreviewParams::class) params: WearWidgetParams,
+) {
+    val widget = remember { HelloWidget() }
+    WearWidgetPreview(
+        widget = widget,
+        params = params,
+    )
+}
+// [END android_wear_widget_preview]
+
+// [START android_wear_widget_content_preview]
+@Preview
+@Composable
+fun HelloWidgetContentPreview(
+    @PreviewParameter(RoundAllWidgetPreviewParams::class) params: WearWidgetParams,
+) {
+    WearWidgetPreview(
+        params = params,
+        background = WearWidgetBrush.color(Color.Blue.rc),
+    ) {
+        HelloWidgetContent()
+    }
+}
+// [END android_wear_widget_content_preview]
+
+// [START android_wear_widget_catalog_preview]
+@Preview(
+    name = "Play Store Catalog Asset",
+    device = "spec:width=1000dp,height=1000dp,dpi=320",
+)
+@Composable
+fun HelloWidgetCatalogPreview(
+    @PreviewParameter(RectangularLargeWidgetPreviewParams::class) params: WearWidgetParams,
+) {
+    WearWidgetPreview(
+        widget = remember { HelloWidget() },
+        params = params,
+    )
+}
+// [END android_wear_widget_catalog_preview]

--- a/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
+++ b/wear/src/main/java/com/example/wear/snippets/widget/GetStarted.kt
@@ -42,7 +42,7 @@ import androidx.glance.wear.WearWidgetData
 import androidx.glance.wear.WearWidgetDocument
 import androidx.glance.wear.color
 import androidx.glance.wear.core.WearWidgetParams
-import androidx.glance.wear.tooling.preview.RectangularLargeWidgetPreviewParams
+import androidx.glance.wear.tooling.preview.RectangularAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.RoundAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.SquircleAllWidgetPreviewParams
 import androidx.glance.wear.tooling.preview.WearWidgetPreview
@@ -139,12 +139,12 @@ fun HelloWidgetContentPreview(
 
 // [START android_wear_widget_catalog_preview]
 @Preview(
-    name = "Play Store Catalog Asset",
+    name = "Widget Preview Asset",
     device = "spec:width=1000dp,height=1000dp,dpi=320",
 )
 @Composable
 fun HelloWidgetCatalogPreview(
-    @PreviewParameter(RectangularLargeWidgetPreviewParams::class) params: WearWidgetParams,
+    @PreviewParameter(RectangularAllWidgetPreviewParams::class) params: WearWidgetParams,
 ) {
     WearWidgetPreview(
         widget = HelloWidget(),


### PR DESCRIPTION
Add Android Studio preview snippets and update glance-wear tooling dependencies for Wear Widgets:
- Update glance-wear to 1.0.0-alpha14.
- Add androidx-glance-wear-tooling-preview dependency.
- Add HelloWidgetPreview, HelloWidgetContentPreview, and HelloWidgetCatalogPreview snippets to GetStarted.kt.