### PR TITLE
Add Kotlin Parcelize snippets

### DIFF
--- a/kmp/shared/build.gradle.kts
+++ b/kmp/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.android.lint)
 }
 
@@ -12,6 +13,10 @@ kotlin {
         namespace = "com.example.kmp.snippets.shared"
         compileSdk = libs.versions.compileSdk.get().toInt()
         minSdk = libs.versions.minSdk.get().toInt()
+
+        compilerOptions {
+            freeCompilerArgs.addAll("-P", "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.example.kmp.snippets.MyParcelize")
+        }
 
         withHostTestBuilder {
         }

--- a/kmp/shared/src/androidMain/kotlin/com/example/kmp/snippets/Parcelize.kt
+++ b/kmp/shared/src/androidMain/kotlin/com/example/kmp/snippets/Parcelize.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.kmp.snippets
+
+// [START android_kotlin_parcelize_multiplatform_platform]
+// Platform code
+// package example
+
+// No typealias for MyParcelize here
+actual typealias MyParcelable = android.os.Parcelable
+actual typealias MyIgnoredOnParcel = kotlinx.parcelize.IgnoredOnParcel
+// [END android_kotlin_parcelize_multiplatform_platform]

--- a/kmp/shared/src/commonMain/kotlin/com/example/kmp/snippets/Parcelize.kt
+++ b/kmp/shared/src/commonMain/kotlin/com/example/kmp/snippets/Parcelize.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.kmp.snippets
+
+// [START android_kotlin_parcelize_multiplatform_common]
+// Common code
+// package example
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+// No `expect` keyword here
+annotation class MyParcelize()
+
+expect interface MyParcelable
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+expect annotation class MyIgnoredOnParcel()
+
+@MyParcelize
+class MyClass(
+    val x: String,
+    @MyIgnoredOnParcel val y: String = ""
+) : MyParcelable
+// [END android_kotlin_parcelize_multiplatform_common]

--- a/kmp/shared/src/iosMain/kotlin/com/example/kmp/snippets/Parcelize.kt
+++ b/kmp/shared/src/iosMain/kotlin/com/example/kmp/snippets/Parcelize.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.kmp.snippets
+
+actual interface MyParcelable
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.SOURCE)
+actual annotation class MyIgnoredOnParcel()

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.parcelize)
 }
 
 kotlin {
@@ -26,6 +27,7 @@ android {
 
         getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro")
         }

--- a/kotlin/src/main/kotlin/com/example/android/basics/Parcelize.kt
+++ b/kotlin/src/main/kotlin/com/example/android/basics/Parcelize.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.basics
+
+import android.os.Parcel
+import android.os.Parcelable
+import kotlinx.parcelize.DataClass
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+import kotlinx.parcelize.TypeParceler
+import kotlinx.parcelize.WriteWith
+import kotlinx.parcelize.parcelableCreator
+
+private object BasicSnippet {
+    // [START android_kotlin_parcelize_basic]
+    // import kotlinx.parcelize.Parcelize
+
+    @Parcelize
+    class User(val firstName: String, val lastName: String, val age: Int) : Parcelable
+    // [END android_kotlin_parcelize_basic]
+}
+
+private object CompanionParcelerSnippet {
+    // [START android_kotlin_parcelize_companion_parceler]
+    @Parcelize
+    data class User(val firstName: String, val lastName: String, val age: Int) : Parcelable {
+        private companion object : Parceler<User> {
+            override fun User.write(parcel: Parcel, flags: Int) {
+                // Custom write implementation
+            }
+
+            override fun create(parcel: Parcel): User {
+                // Custom read implementation
+                // [START_EXCLUDE silent]
+                return User("", "", 0)
+                // [END_EXCLUDE]
+            }
+        }
+    }
+    // [END android_kotlin_parcelize_companion_parceler]
+}
+
+private object ExternalClassParcelerSnippet {
+    // [START android_kotlin_parcelize_external_class_parceler]
+    class ExternalClass(val value: Int)
+
+    object ExternalClassParceler : Parceler<ExternalClass> {
+        override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
+
+        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
+            parcel.writeInt(value)
+        }
+    }
+    // [END android_kotlin_parcelize_external_class_parceler]
+}
+
+private object ClassLocalParcelerSnippet {
+    class ExternalClass(val value: Int)
+
+    object ExternalClassParceler : Parceler<ExternalClass> {
+        override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
+
+        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
+            parcel.writeInt(value)
+        }
+    }
+
+    // [START android_kotlin_parcelize_type_parceler_class]
+    // Class-local parceler
+    @Parcelize
+    @TypeParceler<ExternalClass, ExternalClassParceler>()
+    class MyClass(val external: ExternalClass) : Parcelable
+    // [END android_kotlin_parcelize_type_parceler_class]
+}
+
+private object PropertyLocalParcelerSnippet {
+    class ExternalClass(val value: Int)
+
+    object ExternalClassParceler : Parceler<ExternalClass> {
+        override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
+
+        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
+            parcel.writeInt(value)
+        }
+    }
+
+    // [START android_kotlin_parcelize_type_parceler_property]
+    // Property-local parceler
+    @Parcelize
+    class MyClass(@TypeParceler<ExternalClass, ExternalClassParceler>() val external: ExternalClass) : Parcelable
+    // [END android_kotlin_parcelize_type_parceler_property]
+}
+
+private object TypeLocalParcelerSnippet {
+    class ExternalClass(val value: Int)
+
+    object ExternalClassParceler : Parceler<ExternalClass> {
+        override fun create(parcel: Parcel) = ExternalClass(parcel.readInt())
+
+        override fun ExternalClass.write(parcel: Parcel, flags: Int) {
+            parcel.writeInt(value)
+        }
+    }
+
+    // [START android_kotlin_parcelize_type_parceler_type]
+    // Type-local parceler
+    @Parcelize
+    class MyClass(val external: @WriteWith<ExternalClassParceler>() ExternalClass) : Parcelable
+    // [END android_kotlin_parcelize_type_parceler_type]
+}
+
+private object ParcelableCreatorSnippet {
+    @Parcelize
+    class User(val firstName: String, val lastName: String, val age: Int) : Parcelable
+
+    // [START android_kotlin_parcelize_parcelable_creator]
+    // import kotlinx.parcelize.parcelableCreator
+
+    fun userFromParcel(parcel: Parcel): User {
+        return parcelableCreator<User>().createFromParcel(parcel)
+    }
+    // [END android_kotlin_parcelize_parcelable_creator]
+}
+
+private object IgnoredOnParcelSnippet {
+    // [START android_kotlin_parcelize_ignored_on_parcel]
+    @Parcelize
+    class MyClass(
+        val include: String,
+        // Don't serialize this property
+        @IgnoredOnParcel val ignore: String = "default"
+    ) : Parcelable {
+        // Silence a warning
+        @IgnoredOnParcel
+        val computed: String = include + ignore
+    }
+    // [END android_kotlin_parcelize_ignored_on_parcel]
+}
+
+private object RawValueSnippet {
+    class ExternalClass(val value: Int)
+
+    // [START android_kotlin_parcelize_raw_value]
+    @Parcelize
+    class MyClass(val external: @RawValue ExternalClass) : Parcelable
+    // [END android_kotlin_parcelize_raw_value]
+}
+
+private object SealedClassSnippet {
+    // [START android_kotlin_parcelize_sealed_class]
+    @Parcelize
+    sealed class SealedClass : Parcelable {
+        class A(val a: String) : SealedClass()
+        class B(val b: Int) : SealedClass()
+    }
+
+    @Parcelize
+    class MyClass(val a: SealedClass.A, val b: SealedClass.B, val c: SealedClass) : Parcelable
+    // [END android_kotlin_parcelize_sealed_class]
+}
+
+private object DataWrapperSnippet {
+    // [START android_kotlin_parcelize_data_class_wrapper]
+    // Common code:
+    data class MyData(val x: String, val y: MoreData)
+    data class MoreData(val a: String, val b: Int)
+
+    // Platform code:
+    @OptIn(kotlinx.parcelize.Experimental::class)
+    @Parcelize
+    class DataWrapper(val wrapped: @DataClass MyData) : Parcelable
+    // [END android_kotlin_parcelize_data_class_wrapper]
+}
+
+private object InheritanceBaseSnippet {
+    // [START android_kotlin_parcelize_inheritance_base]
+    // base parcelize
+    @Parcelize
+    open class Base(open val s: String) : Parcelable
+
+    @Parcelize
+    class Derived(
+        val x: Int,
+        // all arguments have to be `val` or `var` so we need to override
+        // to not introduce new property name
+        override val s: String
+    ) : Base(s)
+    // [END android_kotlin_parcelize_inheritance_base]
+}

--- a/kotlin/src/main/kotlin/com/example/android/basics/ParcelizeDataClass.kt
+++ b/kotlin/src/main/kotlin/com/example/android/basics/ParcelizeDataClass.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(kotlinx.parcelize.Experimental::class)
+
+package com.example.android.basics
+
+import android.os.Parcelable
+import kotlinx.parcelize.DataClass
+import kotlinx.parcelize.Parcelize
+
+private object DataClassSnippet {
+    // [START android_kotlin_parcelize_data_class]
+    // @file:OptIn(kotlinx.parcelize.Experimental::class)
+
+    data class C(val a: Int, val b: String)
+
+    @Parcelize
+    class P(val c: @DataClass C) : Parcelable
+    // [END android_kotlin_parcelize_data_class]
+}


### PR DESCRIPTION
# Snippets migration - Kotlin parcelize

Snippets for the Parcelize guide at [developer.android.com/kotlin/parcelize](https://developer.android.com/kotlin/parcelize), extracted into `kotlin/src/main/kotlin/com/example/android/basics/` (`Parcelize.kt` and `ParcelizeDataClass.kt`) with region tags, plus the parcelize plugin in `kotlin/build.gradle.kts`. The multiplatform snippets are added to the `kmp/shared` module (package `com.example.kmp.snippets`).

Fifteen of the page's 24 code blocks are extracted. Most are verbatim; the differences that exist fall into three kinds, described below.

| Region tag (`android_kotlin_parcelize_*`) | Page section | Verbatim | Deviation | Rendered / page |
|---|---|---|---|---|
| `_basic` | intro | no | import shown as a comment; colon spacing | 4 / 4 |
| `_companion_parceler` | intro | yes | — | 12 / 12 |
| `_external_class_parceler` | Custom Parcelers | yes | — | 9 / 9 |
| `_type_parceler_class` | Custom Parcelers | yes | — | 4 / 4 |
| `_type_parceler_property` | Custom Parcelers | yes | — | 3 / 3 |
| `_type_parceler_type` | Custom Parcelers | yes | — | 3 / 3 |
| `_parcelable_creator` | Create data from Parcel | no | import shown as a comment | 5 / 5 |
| `_ignored_on_parcel` | Skip properties from serialization | no | colon spacing | 10 / 10 |
| `_raw_value` | `Parcel.writeValue` | no | colon spacing | 2 / 2 |
| `_sealed_class` | Sealed classes and interfaces | no | colon spacing ×5 | 8 / 8 |
| `_data_class` | Experimental / Data class serializer | no | `@file:OptIn` shown as a comment | 6 / 6 |
| `_data_class_wrapper` | Experimental / Data class serializer | no | colon spacing | 8 / 8 |
| `_inheritance_base` | Experimental / Non `val` or `var` params | no | colon spacing ×2 | 11 / 11 |
| `_multiplatform_common` | Setup Parcelize for Kotlin multiplatform | no | package shown as a comment; colon spacing | 19 / 19 |
| `_multiplatform_platform` | Setup Parcelize for Kotlin multiplatform | no | package shown as a comment | 6 / 6 |

### The three kinds of deviation

**Colon spacing.** The page writes `): Parcelable`; this repo's ktlint config rewrites it to `) : Parcelable`. This is unavoidable — `spotlessApply` makes the change when run — and it accounts for most of the non-verbatim rows above.

**File-top declarations shown as a comment.** The `_basic` and `_parcelable_creator` blocks open with an `import`, `_data_class` opens with `@file:OptIn(kotlinx.parcelize.Experimental::class)`, and the two `_multiplatform_` blocks open with a `package` declaration. Kotlin requires those at the top of the file, above the `package` declaration and outside any snippet region. To keep them visible in the published snippet, the real line lives at the top of the file (uncommented, so it compiles) and a **commented copy** is placed inside the region. The published snippet therefore shows, for example, `// import kotlinx.parcelize.Parcelize` where the page shows a live `import` statement. The page's blocks would be updated to match.

**One experimental block omitted.** The page's "Non `val` or `var` parameters" section has two code blocks: `_inheritance_base` (the non-experimental approach, extracted) and an experimental variant that requires `experimentalCodeGeneration=true`. That flag is a parcelize compiler-plugin argument with module-level granularity — it cannot be scoped to a single snippet, and enabling it module-wide would compile the `kotlin` module's unrelated snippets (coroutines, flow testing) under experimental codegen. The experimental block is therefore not extracted, and the flag is not set. `_inheritance_base` alone still demonstrates the section's point.

### Multiplatform snippets

The Kotlin 2.0+ multiplatform snippets are added to `kmp/shared`: `_multiplatform_common` in `commonMain` and `_multiplatform_platform` in `androidMain`. Two notes:

- **iOS actuals.** The common code declares `expect interface MyParcelable` and `expect annotation class MyIgnoredOnParcel`, so Kotlin requires an `actual` in every target — including iOS. The page says these "can be empty" but does not show them, so `iosMain` gets a small file with empty actuals. It is not a page snippet, so it carries no region tags.
- **Gradle config.** The `additionalAnnotation` compiler argument is applied in `kmp/shared/build.gradle.kts` but left untagged, matching how the page publishes build config (hand-maintained). The page's `example` package becomes `com.example.kmp.snippets`, so the `additionalAnnotation` value points at `com.example.kmp.snippets.MyParcelize`.

### Code not extracted

- **Gradle config** — the [Groovy](https://developer.android.com/kotlin/parcelize#groovy) `plugins` block (this repo is Kotlin DSL only), the [Kotlin DSL](https://developer.android.com/kotlin/parcelize#kts) `plugins` block, and the `experimentalCodeGeneration` block. Build-config blocks are published in their portable `id("…")` form on the page rather than this repo's version-catalog form, so they are left hand-maintained. (The `additionalAnnotation` block is applied but untagged — see "Multiplatform snippets" above.)
- **Java** — the `UserCreator` block under [Create data from Parcel](https://developer.android.com/kotlin/parcelize#create_data_from_parcel). Kotlin only.
- **Multiplatform, pre-Kotlin 2.0** — the two `expect`/`actual` aliasing blocks under [Setup Parcelize for Kotlin multiplatform](https://developer.android.com/kotlin/parcelize#setup_parcelize_for_kotlin_multiplatform). That approach is unsupported in Kotlin 2.0 and higher, which this project uses, so it will not compile. The Kotlin 2.0+ blocks from the same section are extracted — see "Multiplatform snippets" above.
- **The experimental inheritance block** and **the `// ERROR: not allowed` example**, both under [Non val or var parameters in primary constructor](https://developer.android.com/kotlin/parcelize#non_val_or_var_parameters_in_primary_constructor). See "One experimental block omitted" above; the ERROR example cannot compile by design.

### Deprecations

None. Ten imports, all current — `android.os.Parcel`, `android.os.Parcelable` and eight `kotlinx.parcelize` symbols. A forced full recompile produced zero warnings.