### PR TITLE
Add media module

### DIFF
--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
+kotlin {
+    jvmToolchain(17)
+}
+
 android {
     namespace = "com.example.media"
     compileSdk = libs.versions.compileSdk.get().toInt()
@@ -19,13 +23,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-
-    kotlin {
-        jvmToolchain(17)
-    }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.appcompat)
+    implementation(libs.androidx.media3.exoplayer)
 }

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -26,7 +26,5 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.core.ktx)
-    implementation(libs.appcompat)
     implementation(libs.androidx.media3.exoplayer)
 }

--- a/media/build.gradle.kts
+++ b/media/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    alias(libs.plugins.android.application)
+}
+
+android {
+    namespace = "com.example.media"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        applicationId = "com.example.media"
+        minSdk = libs.versions.minSdk.get().toInt()
+        targetSdk = libs.versions.targetSdk.get().toInt()
+        versionCode = 1
+        versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlin {
+        jvmToolchain(17)
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.appcompat)
+}

--- a/media/src/main/AndroidManifest.xml
+++ b/media/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2026 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application />
+
+</manifest>

--- a/media/src/main/java/com/example/media/PlaybackApp.kt
+++ b/media/src/main/java/com/example/media/PlaybackApp.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.media
+
+import android.content.Context
+import androidx.media3.exoplayer.ExoPlayer
+
+private fun createExoPlayer(context: Context) {
+    // [START android_media_playback_app_create_exoplayer]
+    val player = ExoPlayer.Builder(context).build()
+    // [END android_media_playback_app_create_exoplayer]
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,6 +45,7 @@ include(
     ":wear",
     ":wearcompanion",
     ":views",
+    ":media",
     ":misc",
     ":security",
     ":identity:credentialmanager",


### PR DESCRIPTION
Adds an empty `media` application module. This is a prerequisite for the media snippet migrations: the snippets need a module to land in, so this stands one up ahead of the content PRs that follow.

It mirrors the existing minimal modules such as `security`: the `android.application` plugin, namespace `com.example.media`, and SDK versions from the version catalog. Registered in `settings.gradle.kts`.

This work contains one snippet in the source package `com.example.media`, a builder for ExoPlayer.