### PR TITLE
Rework the custom targets sharesheet snippet

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/sharesheet/SharesheetSnippets.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/sharesheet/SharesheetSnippets.kt
@@ -25,7 +25,6 @@ import android.content.Intent.ACTION_SEND
 import android.graphics.drawable.Icon
 import android.net.Uri
 import android.service.chooser.ChooserAction
-import android.service.chooser.ChooserTarget
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.IntentCompat
@@ -176,43 +175,24 @@ fun sharesheetCustomActions(context: Context, previewText: String) {
 // [END android_provide_custom_actions]
 
 fun customTargets(context: Context, previewText: String) {
-    val chooserTargetJessica = ChooserTarget(
-        "ChooserTargetJessica",
-        Icon.createWithResource(context, R.drawable.ic_logo),
-        0f,
-        ComponentName(context.packageName, context.packageName + ".SharesheetActivity"),
-        null
-    )
-    val chooserTargetSpyros = ChooserTarget(
-        "ChooserTargetSpyros",
-        Icon.createWithResource(context, R.drawable.ic_logo),
-        0f,
-        ComponentName(context.packageName, context.packageName + ".SharesheetActivity"),
-        null
-    )
-    val intentTargetNearbyShare = Intent().apply {
-        component = ComponentName(context.packageName, "${context.packageName}.AnActivity")
+// [START android_provide_custom_targets]
+    val sendIntent = Intent(ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, previewText)
     }
-    val intentTargetMaps = Intent(Intent.ACTION_VIEW).apply {
-        setPackage("com.google.android.apps.maps")
+
+    val customIntent = Intent().apply {
+        component = ComponentName(context.packageName, "${context.packageName}.CustomActivity")
     }
-    val sendIntent = Intent(ACTION_SEND)
-        .setType("text/plain")
-        .putExtra(Intent.EXTRA_TEXT, previewText)
-    val shareIntent = Intent.createChooser(sendIntent, null)
-    // [START android_provide_custom_targets]
-    val share = Intent.createChooser(shareIntent, null).apply {
-        putExtra(
-            Intent.EXTRA_CHOOSER_TARGETS,
-            arrayOf(chooserTargetJessica, chooserTargetSpyros)
-        )
+
+    val shareIntent = Intent.createChooser(sendIntent, null).apply {
         putExtra(
             Intent.EXTRA_INITIAL_INTENTS,
-            arrayOf(intentTargetNearbyShare, intentTargetMaps)
+            arrayOf(customIntent)
         )
     }
-    // [END android_provide_custom_targets]
-    context.startActivity(share)
+    context.startActivity(shareIntent)
+// [END android_provide_custom_targets]
 }
 
 // [START android_exclude_specific_targets]


### PR DESCRIPTION
Reworks the `android_provide_custom_targets` snippet used by the "Add custom targets" section of https://developer.android.com/develop/ui/compose/sharing/send#adding-custom-targets.

The snippet on the page builds two `ChooserTarget` instances and passes them through `EXTRA_CHOOSER_TARGETS`. `ChooserTarget` has been deprecated since API level 30, and its documentation points to Direct Share targets instead. The section it illustrates is about `EXTRA_INITIAL_INTENTS`, so the `ChooserTarget` part was not needed to make the point.

What changed:

- Removed the two `ChooserTarget` instances and the `EXTRA_CHOOSER_TARGETS` extra, along with the now unused `ChooserTarget` import.
- Removed the double `Intent.createChooser` call. The old code wrapped an already-created chooser in a second chooser, which is not what the guide describes.
- Reduced the initial intents from two to one, and gave it a name that reads as an example (`CustomActivity`) rather than pointing at Nearby Share and Maps.
- Moved the region tags so the snippet shows only the chooser construction.

This deviates from the current page text, which still shows the `ChooserTarget` version. The page needs the same update.
