### PR TITLE
Migrate Snackbar snippets (showing and action)

### DIFF
--- a/compose/snippets/src/main/java/com/example/compose/snippets/components/Snackbar.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/components/Snackbar.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.components
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult.ActionPerformed
+import androidx.compose.material3.SnackbarResult.Dismissed
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.launch
+
+@Composable
+private fun DACPlaygroundTheme(content: @Composable () -> Unit) {
+    MaterialTheme(content = content)
+}
+
+private class SnackbarActionActivity : ComponentActivity() {
+
+    // [START android_compose_components_snackbar_host]
+    override fun onCreate(savedInstanceState: Bundle?) {
+
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            DACPlaygroundTheme {
+                val snackbarHostState = remember { SnackbarHostState() }
+                val scope = rememberCoroutineScope()
+                Scaffold(
+                    snackbarHost = { SnackbarHost(snackbarHostState) },
+                    content = { padding ->
+                        Button(
+                            modifier = Modifier.padding(padding),
+                            onClick = {
+                                scope.launch {
+                                    snackbarHostState.showSnackbar(
+                                        message = "1 item removed",
+                                        actionLabel = "UNDO",
+                                        duration = SnackbarDuration.Short
+                                    ).run {
+                                        when (this) {
+                                            Dismissed -> Log.d("SNACKBAR", "Dismissed")
+                                            ActionPerformed -> Log.d("SNACKBAR", "UNDO CLICKED")
+                                        }
+                                    }
+                                }
+                            }
+                        ) { Text("Show snackbar") }
+                    }
+                )
+            }
+        }
+    }
+    // [END android_compose_components_snackbar_host]
+}

--- a/views/src/main/java/com/example/example/snippet/views/notifications/snackbar/Action.kt
+++ b/views/src/main/java/com/example/example/snippet/views/notifications/snackbar/Action.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.example.snippet.views.notifications.snackbar
+
+import android.view.View
+import androidx.activity.ComponentActivity
+import com.example.example.snippet.views.R
+import com.google.android.material.snackbar.Snackbar
+
+// [START android_views_snackbar_action_listener]
+class MyUndoListener : View.OnClickListener {
+
+    override fun onClick(v: View) {
+        // Code to undo the user's last action.
+    }
+}
+// [END android_views_snackbar_action_listener]
+
+private class ActionActivity : ComponentActivity() {
+
+    fun setupActionSnackbar() {
+        // [START android_views_snackbar_set_action]
+        val mySnackbar = Snackbar.make(
+            findViewById(R.id.myCoordinatorLayout),
+            R.string.email_archived,
+            Snackbar.LENGTH_SHORT
+        )
+        mySnackbar.setAction(R.string.undo_string, MyUndoListener())
+        mySnackbar.show()
+        // [END android_views_snackbar_set_action]
+    }
+}

--- a/views/src/main/java/com/example/example/snippet/views/notifications/snackbar/Showing.kt
+++ b/views/src/main/java/com/example/example/snippet/views/notifications/snackbar/Showing.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.example.snippet.views.notifications.snackbar
+
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.annotation.StringRes
+import com.example.example.snippet.views.R
+import com.google.android.material.snackbar.Snackbar
+
+private class ShowingActivity : ComponentActivity() {
+
+    fun showSnackbar(view: View, @StringRes stringId: Int, duration: Int) {
+        // [START android_views_snackbar_make]
+        val mySnackbar = Snackbar.make(view, stringId, duration)
+        // [END android_views_snackbar_make]
+
+        // [START android_views_snackbar_show]
+        mySnackbar.show()
+        // [END android_views_snackbar_show]
+    }
+
+    fun showChainedSnackbar() {
+        // [START android_views_snackbar_make_show]
+        Snackbar.make(
+            findViewById(R.id.myCoordinatorLayout),
+            R.string.email_sent,
+            Snackbar.LENGTH_SHORT
+        ).show()
+        // [END android_views_snackbar_make_show]
+    }
+}

--- a/views/src/main/res/values/ids.xml
+++ b/views/src/main/res/values/ids.xml
@@ -15,6 +15,5 @@
      limitations under the License.
 -->
 <resources>
-    <string name="empty_view_text">Empty</string>
-    <string name="email_sent">Email sent</string>
+    <item name="myCoordinatorLayout" type="id" />
 </resources>

--- a/views/src/main/res/values/strings.xml
+++ b/views/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
 <resources>
     <string name="empty_view_text">Empty</string>
     <string name="email_sent">Email sent</string>
+    <string name="email_archived">Email archived</string>
+    <string name="undo_string">Undo</string>
 </resources>


### PR DESCRIPTION
Code snippets are for:
* https://developer.android.com/develop/ui/views/notifications/snackbar/showing
* https://developer.android.com/develop/ui/views/notifications/snackbar/action

List of modifications:
* Showing page: Added Kotlin snippets for creating and displaying a Snackbar using Snackbar.make() and .show(), as well as chained invocation (`views` module).
* Showing page: Added the CoordinatorLayout skeleton as a layout resource (`views` module). It declares `@+id/myCoordinatorLayout`, which the chained `Snackbar.make()` snippet looks up.
* Action page: Added Kotlin snippets for Snackbar.setAction with custom OnClickListener and SnackbarHost with SnackbarHostState in Compose (`views` and `compose:snippets` modules).

Deviations from the page:
* The layout snippet uses `androidx.coordinatorlayout.widget.CoordinatorLayout`. The page shows `android.support.design.widget.CoordinatorLayout`, which is the Support Library class and is no longer available. The page text needs the same change.
* The layout snippet drops the unused `xmlns:app` declaration.
