### PR TITLE
Migrate Intelligent Experiences (Socialite and ADK) snippets

### DIFF
--- a/ai/build.gradle.kts
+++ b/ai/build.gradle.kts
@@ -67,6 +67,8 @@ dependencies {
     implementation(libs.firebase.ai)
     implementation(libs.firebase.ondevice)
     implementation(libs.guava.android)
+    implementation(libs.google.adk.core.android)
+    ksp(libs.google.adk.processor)
     implementation(libs.mlkit.genai.prompt)
     ksp(libs.genai.schema.compiler)
     testImplementation(libs.junit)

--- a/ai/src/main/java/com/example/snippets/ai/Adk.kt
+++ b/ai/src/main/java/com/example/snippets/ai/Adk.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.ai
+
+import com.google.mlkit.genai.prompt.GenerativeModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+
+// [START android_ai_adk_define_agent]
+class TimeService {
+    /** Mock tool implementation */
+    @Tool
+    fun getCurrentTime(
+        @Param("Name of the city to get the time for") city: String
+    ): Map<String, String> {
+        return mapOf("city" to city, "time" to "The time is 10:30am.")
+    }
+}
+
+object HelloTimeAgent {
+    @JvmField
+    val rootAgent = LlmAgent(
+        name = "hello_time_agent",
+        description = "Tells the current time in a specified city.",
+        model = Gemini(
+            name = "gemini-flash-latest",
+            apiKey = System.getenv("GOOGLE_API_KEY")
+                ?: error("GOOGLE_API_KEY environment variable not set."),
+        ),
+        instruction = Instruction(
+            "You are a helpful assistant that tells the current time in a city. "
+                + "Use the 'getCurrentTime' tool for this purpose."
+        ),
+        tools = TimeService().generatedTools(),
+    )
+}
+// [END android_ai_adk_define_agent]
+
+private fun runAgentExample(scope: CoroutineScope) {
+    // [START android_ai_adk_run_agent]
+    // Create a runner and session service
+    val sessionService = InMemorySessionService()
+    val runner = InMemoryRunner(
+        agent = HelloTimeAgent.rootAgent,
+        sessionService = sessionService,
+    )
+    // Call the agent from a coroutine (e.g. in a ViewModel or Activity)
+    scope.launch {
+        runner.runAsync(
+            userId = "user-123",
+            sessionId = "session-123",
+            newMessage = Content(
+                role = Role.USER,
+                parts = listOf(Part(text = "What time is it in New York?")),
+            ),
+        ).collect { event ->
+            val text = event.content?.parts?.firstOrNull()?.text
+            if (!text.isNullOrBlank()) {
+                // Update your UI with the agent's response
+            }
+        }
+    }
+    // [END android_ai_adk_run_agent]
+}
+
+private fun onDeviceModelExample(generativeModel: GenerativeModel) {
+    // [START android_ai_adk_on_device_models]
+    // Create an ML Kit GenerativeModel for on-device inference
+    // [START_EXCLUDE silent]
+    /*
+    // [END_EXCLUDE]
+    val generativeModel: GenerativeModel = // ... initialize using ML Kit
+    // [START_EXCLUDE silent]
+    */
+    // [END_EXCLUDE]
+    val onDeviceModel = GenaiPrompt.create(
+        generativeModel = generativeModel,
+        name = "gemini-nano",
+    )
+    val agent = LlmAgent(
+        name = "on_device_agent",
+        model = onDeviceModel,
+        instruction = Instruction("You are a helpful assistant."),
+    )
+    // [END android_ai_adk_on_device_models]
+}
+
+annotation class Tool
+annotation class Param(val value: String)
+
+class Instruction(val value: String)
+open class BaseModel
+class Gemini(val name: String, val apiKey: String) : BaseModel()
+
+class LlmAgent(
+    val name: String,
+    val description: String = "",
+    val model: BaseModel,
+    val instruction: Instruction,
+    val tools: List<Any> = emptyList(),
+)
+
+fun TimeService.generatedTools(): List<Any> = emptyList()
+
+class InMemorySessionService
+class InMemoryRunner(val agent: LlmAgent, val sessionService: InMemorySessionService) {
+    fun runAsync(userId: String, sessionId: String, newMessage: Content): Flow<AdkRunnerEvent> = flowOf()
+}
+
+enum class Role { USER, MODEL }
+class Part(val text: String)
+class Content(val role: Role, val parts: List<Part>)
+class AdkRunnerEvent(val content: Content?)
+
+object GenaiPrompt {
+    fun create(generativeModel: GenerativeModel, name: String): BaseModel = BaseModel()
+}

--- a/ai/src/main/java/com/example/snippets/ai/Adk.kt
+++ b/ai/src/main/java/com/example/snippets/ai/Adk.kt
@@ -16,10 +16,19 @@
 
 package com.example.snippets.ai
 
+import com.google.adk.kt.agents.Instruction
+import com.google.adk.kt.agents.LlmAgent
+import com.google.adk.kt.annotations.Param
+import com.google.adk.kt.annotations.Tool
+import com.google.adk.kt.models.Gemini
+import com.google.adk.kt.models.mlkit.GenaiPrompt
+import com.google.adk.kt.runners.InMemoryRunner
+import com.google.adk.kt.sessions.InMemorySessionService
+import com.google.adk.kt.types.Content
+import com.google.adk.kt.types.Part
+import com.google.adk.kt.types.Role
 import com.google.mlkit.genai.prompt.GenerativeModel
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
 // [START android_ai_adk_define_agent]
@@ -44,8 +53,8 @@ object HelloTimeAgent {
                 ?: error("GOOGLE_API_KEY environment variable not set."),
         ),
         instruction = Instruction(
-            "You are a helpful assistant that tells the current time in a city. "
-                + "Use the 'getCurrentTime' tool for this purpose."
+            "You are a helpful assistant that tells the current time in a city. " +
+                "Use the 'getCurrentTime' tool for this purpose."
         ),
         tools = TimeService().generatedTools(),
     )
@@ -79,7 +88,7 @@ private fun runAgentExample(scope: CoroutineScope) {
     // [END android_ai_adk_run_agent]
 }
 
-private fun onDeviceModelExample(generativeModel: GenerativeModel) {
+private fun onDeviceModelExample(mockGenerativeModel: GenerativeModel) {
     // [START android_ai_adk_on_device_models]
     // Create an ML Kit GenerativeModel for on-device inference
     // [START_EXCLUDE silent]
@@ -87,7 +96,8 @@ private fun onDeviceModelExample(generativeModel: GenerativeModel) {
     // [END_EXCLUDE]
     val generativeModel: GenerativeModel = // ... initialize using ML Kit
     // [START_EXCLUDE silent]
-    */
+     */
+    val generativeModel: GenerativeModel = mockGenerativeModel
     // [END_EXCLUDE]
     val onDeviceModel = GenaiPrompt.create(
         generativeModel = generativeModel,
@@ -99,35 +109,4 @@ private fun onDeviceModelExample(generativeModel: GenerativeModel) {
         instruction = Instruction("You are a helpful assistant."),
     )
     // [END android_ai_adk_on_device_models]
-}
-
-annotation class Tool
-annotation class Param(val value: String)
-
-class Instruction(val value: String)
-open class BaseModel
-class Gemini(val name: String, val apiKey: String) : BaseModel()
-
-class LlmAgent(
-    val name: String,
-    val description: String = "",
-    val model: BaseModel,
-    val instruction: Instruction,
-    val tools: List<Any> = emptyList(),
-)
-
-fun TimeService.generatedTools(): List<Any> = emptyList()
-
-class InMemorySessionService
-class InMemoryRunner(val agent: LlmAgent, val sessionService: InMemorySessionService) {
-    fun runAsync(userId: String, sessionId: String, newMessage: Content): Flow<AdkRunnerEvent> = flowOf()
-}
-
-enum class Role { USER, MODEL }
-class Part(val text: String)
-class Content(val role: Role, val parts: List<Part>)
-class AdkRunnerEvent(val content: Content?)
-
-object GenaiPrompt {
-    fun create(generativeModel: GenerativeModel, name: String): BaseModel = BaseModel()
 }

--- a/ai/src/main/java/com/example/snippets/ai/Socialite.kt
+++ b/ai/src/main/java/com/example/snippets/ai/Socialite.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.snippets.ai
+
+import com.google.firebase.Firebase
+import com.google.firebase.ai.Chat
+import com.google.firebase.ai.GenerativeModel
+import com.google.firebase.ai.ai
+import com.google.firebase.ai.type.Content
+import com.google.firebase.ai.type.PublicPreviewAPI
+import com.google.firebase.ai.type.content
+
+@OptIn(PublicPreviewAPI::class)
+private fun createGenerativeModel(): GenerativeModel {
+    // [START android_ai_socialite_generative_model]
+    val generativeModel = GenerativeModel(
+        // Set the model name to the latest Gemini model.
+        modelName = "gemini-2.0-flash-lite-001",
+        // Set a system instruction to set the behavior of the model.
+        systemInstruction = content {
+            text("Please respond to this chat conversation like a friendly cat.")
+        },
+    )
+    // [END android_ai_socialite_generative_model]
+    return generativeModel
+}
+
+@OptIn(PublicPreviewAPI::class)
+private fun startChatExample(generativeModel: GenerativeModel, chatId: String): Chat {
+    // [START android_ai_socialite_start_chat]
+    val pastMessages = getMessageHistory(chatId)
+    val chat = generativeModel.startChat(
+        history = pastMessages,
+    )
+    // [END android_ai_socialite_start_chat]
+    return chat
+}
+
+@OptIn(PublicPreviewAPI::class)
+private fun GenerativeModel(
+    modelName: String,
+    systemInstruction: Content? = null,
+): GenerativeModel {
+    return Firebase.ai.generativeModel(
+        modelName = modelName,
+        systemInstruction = systemInstruction,
+    )
+}
+
+private fun getMessageHistory(chatId: String): List<Content> = emptyList()

--- a/ai/src/main/java/com/example/snippets/ai/Socialite.kt
+++ b/ai/src/main/java/com/example/snippets/ai/Socialite.kt
@@ -27,7 +27,7 @@ import com.google.firebase.ai.type.content
 @OptIn(PublicPreviewAPI::class)
 private fun createGenerativeModel(): GenerativeModel {
     // [START android_ai_socialite_generative_model]
-    val generativeModel = GenerativeModel(
+    val generativeModel = Firebase.ai.generativeModel(
         // Set the model name to the latest Gemini model.
         modelName = "gemini-2.0-flash-lite-001",
         // Set a system instruction to set the behavior of the model.
@@ -48,17 +48,6 @@ private fun startChatExample(generativeModel: GenerativeModel, chatId: String): 
     )
     // [END android_ai_socialite_start_chat]
     return chat
-}
-
-@OptIn(PublicPreviewAPI::class)
-private fun GenerativeModel(
-    modelName: String,
-    systemInstruction: Content? = null,
-): GenerativeModel {
-    return Firebase.ai.generativeModel(
-        modelName = modelName,
-        systemInstruction = systemInstruction,
-    )
 }
 
 private fun getMessageHistory(chatId: String): List<Content> = emptyList()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ fragment-testing = "1.9.0"
 genaiSchemaCompiler = "1.0.0-alpha1"
 glance-wear = "1.0.0-alpha14"
 glide = "1.0.0-beta10"
+google-adk = "0.1.0"
 google-ar-core = "1.54.0"
 google-maps = "20.0.0"
 gradle-versions = "0.59.0"
@@ -301,6 +302,8 @@ genai-schema-compiler = { module = "com.google.mlkit:genai-schema-compiler", ver
 glance-appwidget-preview = { module = "androidx.glance:glance-appwidget-preview", version.ref = "androidx-glance-appwidget" }
 glance-preview = { module = "androidx.glance:glance-preview", version.ref = "androidx-glance-appwidget" }
 glide-compose = { module = "com.github.bumptech.glide:compose", version.ref = "glide" }
+google-adk-core-android = { module = "com.google.adk:google-adk-kotlin-core-android", version.ref = "google-adk" }
+google-adk-processor = { module = "com.google.adk:google-adk-kotlin-processor", version.ref = "google-adk" }
 google-android-material = { module = "com.google.android.material:material", version.ref = "material" }
 google-ar-core = { module = "com.google.ar:core", version.ref = "google-ar-core" }
 google-protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "protobuf" }


### PR DESCRIPTION
Code snippets are for:
- https://developer.android.com/ai/samples/socialite
- https://developer.android.com/ai/adk

List of modifications:
- Socialite page: Migrated 2 code snippets (generative model initialization and starting a chat). Used Firebase.ai.generativeModel API.
- Adk page: Migrated 3 code snippets (agent definition, running agent, on-device models with ML Kit). Added official com.google.adk:google-adk-kotlin-core-android and google-adk-kotlin-processor dependencies to ai module. Used D23 twin pattern for on-device ML Kit initialization placeholder.

Snippets not migrated:
- Adk page: build.gradle.kts dependency configuration block because it is a Gradle configuration block.