### PR TITLE
Add CameraX take-a-photo snippets

### DIFF
--- a/camerax/src/main/java/com/example/camerax/snippets/TakePhoto.kt
+++ b/camerax/src/main/java/com/example/camerax/snippets/TakePhoto.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.camerax.snippets
+
+import android.view.View
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.lifecycle.LifecycleOwner
+import java.io.File
+import java.util.concurrent.Executor
+
+private fun setUpCamera(
+    view: View,
+    cameraProvider: ProcessCameraProvider,
+    lifecycleOwner: LifecycleOwner,
+    cameraSelector: CameraSelector,
+    preview: Preview,
+) {
+    // [START android_camerax_take_photo_setup]
+    val imageCapture = ImageCapture.Builder()
+        .setTargetRotation(view.display.rotation)
+        .build()
+
+    cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, imageCapture, preview)
+    // [END android_camerax_take_photo_setup]
+}
+
+private class TakePhoto(
+    private val imageCapture: ImageCapture,
+    private val cameraExecutor: Executor,
+) {
+    // [START android_camerax_take_photo_save_to_file]
+    fun onClick() {
+        val outputFileOptions = ImageCapture.OutputFileOptions.Builder(File("photo.jpg")).build()
+        imageCapture.takePicture(
+            outputFileOptions, cameraExecutor,
+            object : ImageCapture.OnImageSavedCallback {
+                override fun onError(error: ImageCaptureException) {
+                    // Insert your code here
+                }
+                override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+                    // Insert your code here
+                }
+            }
+        )
+    }
+    // [END android_camerax_take_photo_save_to_file]
+}


### PR DESCRIPTION
Code snippets are for: [Take a photo with CameraX](https://developer.android.com/media/camera/camerax/take-photo)

Two Kotlin blocks, into `camerax/src/main/java/com/example/camerax/snippets/TakePhoto.kt`.

| Region tag | Page section | Same as the page? | Lines snippet/page |
|---|---|---|---|
| `android_camerax_take_photo_setup` | Set up the camera | Yes | 5/5 |
| `android_camerax_take_photo_save_to_file` | Take a picture | Three lines differ, see below | 14/13 |

The line-count difference is line splits, not different code. A paste test confirms it: the page's block, pasted unchanged and run through `spotlessApply`, gives exactly this file's form.

## List of modifications

**`File(...)` becomes `File("photo.jpg")`.** The page prints `Builder(File(...)).build()`, which is not valid Kotlin. An earlier draft of this extraction kept the page's line inside a block comment with a real value hidden beside it, so the rendered page stayed byte-identical. The docs team asked for a placeholder file name instead, accepting the visible page change, so the snippet binds the value once and the page changes to match.

**`// insert your code here.` becomes `// Insert your code here`**, in both callbacks. The page prints the lowercase form with a full stop in its Kotlin and its Java block. Capitalized and without the stop matches the comment style in this repository.

All three are page edits. They are listed again at the end.

## What the formatter moved

Three changes, all from `spotlessApply`:

- `takePicture(` wraps, and the two arguments stay together on the next line.
- The `onError` brace joins its declaration.
- The call closes as `}` then `)`, not `})`.

To reproduce: paste the page's Kotlin block into `camerax` and run `./gradlew :camerax:spotlessApply`.

## Snippets not migrated

| Block | Page line | Lines | Why |
|---|---|---|---|
| Java, Set up the camera | 59 | 6 | This module is Kotlin only |
| Java, Take a picture | 93 | 16 | This module is Kotlin only |

## For the page edit

- `File(...)` becomes `File("photo.jpg")` in the Kotlin block.
- `// insert your code here.` becomes `// Insert your code here` in both callbacks, in the Kotlin block and in the Java block.
- Two Java samples to retire: Set up the camera, Take a picture.
- The Kotlin block puts the `onError` brace on its own line. No other block on the page does this.
- The Kotlin block orders the callbacks `onError` then `onImageSaved`. The Java block below it uses the opposite order.

No deprecated APIs. The prose names `ImageCapture`, `takePicture`, `OutputFileOptions` and `OnImageSavedCallback`, and those stay as published.
