### PR TITLE
Katherinekuan/architecture modularization snippets fix

### DIFF
--- a/compose/snippets/build.gradle.kts
+++ b/compose/snippets/build.gradle.kts
@@ -77,6 +77,8 @@ android {
 
 dependencies {
     implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.room.common)
+    implementation(libs.androidx.startup.runtime)
     implementation(libs.androidx.media3.session)
     implementation(libs.glance.preview)
     val composeBom = platform(libs.androidx.compose.bom)

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/DataLayer.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/DataLayer.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import java.util.Date
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+private object DataLayerSnippet1 {
+    interface ExampleRemoteDataSource
+    interface ExampleLocalDataSource
+
+    // [START android_architecture_data_layer_repository_constructor]
+    class ExampleRepository(
+        // network
+        private val exampleRemoteDataSource: ExampleRemoteDataSource,
+        // database
+        private val exampleLocalDataSource: ExampleLocalDataSource
+    ) { /* ... */ }
+    // [END android_architecture_data_layer_repository_constructor]
+}
+
+private object DataLayerSnippet2 {
+    interface ExampleRemoteDataSource
+    interface ExampleLocalDataSource
+    class Example
+
+    // [START android_architecture_data_layer_expose_apis]
+    class ExampleRepository(
+        // network
+        private val exampleRemoteDataSource: ExampleRemoteDataSource,
+        // database
+        private val exampleLocalDataSource: ExampleLocalDataSource
+    ) {
+
+        val data: Flow<Example> = /* [START_EXCLUDE] */ flowOf(Example()) /* [END_EXCLUDE] */
+
+        suspend fun modifyData(example: Example) { /* [START_EXCLUDE silent] */ /* [END_EXCLUDE] */ }
+    }
+    // [END android_architecture_data_layer_expose_apis]
+}
+
+private object DataLayerSnippet3 {
+    class CommentApiModel
+
+    // [START android_architecture_data_layer_network_model]
+    data class ArticleApiModel(
+        val id: Long,
+        val title: String,
+        val content: String,
+        val publicationDate: Date,
+        val modifications: Array<ArticleApiModel>,
+        val comments: Array<CommentApiModel>,
+        val lastModificationDate: Date,
+        val authorId: Long,
+        val authorName: String,
+        val authorDateOfBirth: Date,
+        val readTimeMin: Int
+    )
+    // [END android_architecture_data_layer_network_model]
+}
+
+private object DataLayerSnippet4 {
+    // [START android_architecture_data_layer_business_model]
+    data class Article(
+        val id: Long,
+        val title: String,
+        val content: String,
+        val publicationDate: Date,
+        val authorName: String,
+        val readTimeMin: Int
+    )
+    // [END android_architecture_data_layer_business_model]
+}
+
+private object DataLayerSnippet5 {
+    data class ArticleHeadline(val title: String)
+
+    // [START android_architecture_data_layer_news_remote_data_source]
+    class NewsRemoteDataSource(
+        private val newsApi: NewsApi,
+        private val ioDispatcher: CoroutineDispatcher
+    ) {
+        /**
+         * Fetches the latest news from the network and returns the result.
+         * This executes on an IO-optimized thread pool, the function is main-safe.
+         */
+        suspend fun fetchLatestNews(): List<ArticleHeadline> =
+            // Move the execution to an IO-optimized thread since the ApiService
+            // doesn't support coroutines and makes synchronous requests.
+            withContext(ioDispatcher) {
+                newsApi.fetchLatestNews()
+            }
+    }
+
+    // Makes news-related network synchronous requests.
+    interface NewsApi {
+        fun fetchLatestNews(): List<ArticleHeadline>
+    }
+    // [END android_architecture_data_layer_news_remote_data_source]
+}
+
+private object DataLayerSnippet6 {
+    data class ArticleHeadline(val title: String)
+    class NewsRemoteDataSource {
+        fun fetchLatestNews(): List<ArticleHeadline> = emptyList()
+    }
+
+    // [START android_architecture_data_layer_news_repository_fetch]
+    // NewsRepository is consumed from other layers of the hierarchy.
+    class NewsRepository(
+        private val newsRemoteDataSource: NewsRemoteDataSource
+    ) {
+        suspend fun fetchLatestNews(): List<ArticleHeadline> =
+            newsRemoteDataSource.fetchLatestNews()
+    }
+    // [END android_architecture_data_layer_news_repository_fetch]
+}
+
+private object DataLayerSnippet7 {
+    data class ArticleHeadline(val title: String)
+    class NewsRemoteDataSource {
+        fun fetchLatestNews(): List<ArticleHeadline> = emptyList()
+    }
+
+    // [START android_architecture_data_layer_in_memory_cache]
+    class NewsRepository(
+        private val newsRemoteDataSource: NewsRemoteDataSource
+    ) {
+        // Mutex to make writes to cached values thread-safe.
+        private val latestNewsMutex = Mutex()
+
+        // Cache of the latest news got from the network.
+        private var latestNews: List<ArticleHeadline> = emptyList()
+
+        suspend fun getLatestNews(refresh: Boolean = false): List<ArticleHeadline> {
+            if (refresh || latestNews.isEmpty()) {
+                val networkResult = newsRemoteDataSource.fetchLatestNews()
+                // Thread-safe write to latestNews
+                latestNewsMutex.withLock {
+                    this.latestNews = networkResult
+                }
+            }
+
+            return latestNewsMutex.withLock { this.latestNews }
+        }
+    }
+    // [END android_architecture_data_layer_in_memory_cache]
+}
+
+private object DataLayerSnippet8 {
+    class NewsRemoteDataSource
+
+    // [START android_architecture_data_layer_external_scope_constructor]
+    class NewsRepository(
+        /* [START_EXCLUDE] */
+        newsRemoteDataSource: NewsRemoteDataSource,
+        /* [END_EXCLUDE] */
+        // This could be CoroutineScope(SupervisorJob() + Dispatchers.Default).
+        private val externalScope: CoroutineScope
+    ) { /* ... */ }
+    // [END android_architecture_data_layer_external_scope_constructor]
+}
+
+private object DataLayerSnippet9 {
+    data class ArticleHeadline(val title: String)
+    class NewsRemoteDataSource {
+        fun fetchLatestNews(): List<ArticleHeadline> = emptyList()
+    }
+
+    // [START android_architecture_data_layer_external_scope_async]
+    class NewsRepository(
+        private val newsRemoteDataSource: NewsRemoteDataSource,
+        private val externalScope: CoroutineScope
+    ) {
+        /* ... */
+        /* [START_EXCLUDE silent] */
+        private val latestNewsMutex = Mutex()
+        private var latestNews: List<ArticleHeadline> = emptyList()
+        /* [END_EXCLUDE] */
+
+        suspend fun getLatestNews(refresh: Boolean = false): List<ArticleHeadline> {
+            return if (refresh) {
+                externalScope.async {
+                    newsRemoteDataSource.fetchLatestNews().also { networkResult ->
+                        // Thread-safe write to latestNews.
+                        latestNewsMutex.withLock {
+                            latestNews = networkResult
+                        }
+                    }
+                }.await()
+            } else {
+                return latestNewsMutex.withLock { this.latestNews }
+            }
+        }
+    }
+    // [END android_architecture_data_layer_external_scope_async]
+}
+
+private object DataLayerSnippet10 {
+    class NewsRepository {
+        fun refreshLatestNews() {}
+    }
+
+    // [START android_architecture_data_layer_refresh_latest_news_worker]
+    class RefreshLatestNewsWorker(
+        private val newsRepository: NewsRepository,
+        context: Context,
+        params: WorkerParameters
+    ) : CoroutineWorker(context, params) {
+
+        override suspend fun doWork(): Result = try {
+            newsRepository.refreshLatestNews()
+            Result.success()
+        } catch (error: Throwable) {
+            Result.failure()
+        }
+    }
+    // [END android_architecture_data_layer_refresh_latest_news_worker]
+}
+
+private object DataLayerSnippet11 {
+    class RefreshLatestNewsWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+        override suspend fun doWork(): Result = Result.success()
+    }
+
+    // [START android_architecture_data_layer_news_tasks_data_source]
+    private const val REFRESH_RATE_HOURS = 4L
+    private const val FETCH_LATEST_NEWS_TASK = "FetchLatestNewsTask"
+    private const val TAG_FETCH_LATEST_NEWS = "FetchLatestNewsTaskTag"
+
+    class NewsTasksDataSource(
+        private val workManager: WorkManager
+    ) {
+        fun fetchNewsPeriodically() {
+            val fetchNewsRequest = PeriodicWorkRequestBuilder<RefreshLatestNewsWorker>(
+                REFRESH_RATE_HOURS, TimeUnit.HOURS
+            ).setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.TEMPORARILY_UNMETERED)
+                    .setRequiresCharging(true)
+                    .build()
+            )
+                .addTag(TAG_FETCH_LATEST_NEWS)
+
+            workManager.enqueueUniquePeriodicWork(
+                FETCH_LATEST_NEWS_TASK,
+                ExistingPeriodicWorkPolicy.KEEP,
+                fetchNewsRequest.build()
+            )
+        }
+
+        fun cancelFetchingNewsPeriodically() {
+            workManager.cancelAllWorkByTag(TAG_FETCH_LATEST_NEWS)
+        }
+    }
+    // [END android_architecture_data_layer_news_tasks_data_source]
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/DomainLayer.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/DomainLayer.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import androidx.lifecycle.ViewModel
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private object DomainLayerSnippet1 {
+    interface NewsRepository
+    interface AuthorsRepository
+
+    // [START android_architecture_domain_layer_dependencies]
+    class GetLatestNewsWithAuthorsUseCase(
+        private val newsRepository: NewsRepository,
+        private val authorsRepository: AuthorsRepository
+    ) { /* ... */ }
+    // [END android_architecture_domain_layer_dependencies]
+}
+
+private object DomainLayerSnippet2 {
+    interface NewsRepository
+    interface AuthorsRepository
+    class FormatDateUseCase
+
+    // [START android_architecture_domain_layer_nested_dependencies]
+    class GetLatestNewsWithAuthorsUseCase(
+        private val newsRepository: NewsRepository,
+        private val authorsRepository: AuthorsRepository,
+        private val formatDateUseCase: FormatDateUseCase
+    ) { /* ... */ }
+    // [END android_architecture_domain_layer_nested_dependencies]
+}
+
+private object DomainLayerSnippet3 {
+    interface UserRepository {
+        fun getPreferredDateFormat(): String = "yyyy-MM-dd"
+        fun getPreferredLocale(): Locale = Locale.getDefault()
+    }
+
+    // [START android_architecture_domain_layer_format_date_use_case]
+    class FormatDateUseCase(userRepository: UserRepository) {
+
+        private val formatter = SimpleDateFormat(
+            userRepository.getPreferredDateFormat(),
+            userRepository.getPreferredLocale()
+        )
+
+        operator fun invoke(date: Date): String {
+            return formatter.format(date)
+        }
+    }
+    // [END android_architecture_domain_layer_format_date_use_case]
+}
+
+private object DomainLayerSnippet4 {
+    class FormatDateUseCase {
+        operator fun invoke(date: Date): String = ""
+        operator fun invoke(calendar: Calendar): String = invoke(calendar.time)
+    }
+
+    // [START android_architecture_domain_layer_call_use_case_viewmodel]
+    class MyViewModel(formatDateUseCase: FormatDateUseCase) : ViewModel() {
+        init {
+            val today = Calendar.getInstance()
+            val todaysDate = formatDateUseCase(today)
+            /* ... */
+        }
+    }
+    // [END android_architecture_domain_layer_call_use_case_viewmodel]
+}
+
+private object DomainLayerSnippet5 {
+    // [START android_architecture_domain_layer_threading]
+    class MyUseCase(
+        private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+    ) {
+
+        suspend operator fun invoke(/* ... */) = withContext(defaultDispatcher) {
+            // Long-running blocking operations happen on a background thread.
+        }
+    }
+    // [END android_architecture_domain_layer_threading]
+}
+
+private object DomainLayerSnippet6 {
+    data class Article(val authorId: String)
+    data class Author(val id: String)
+    data class ArticleWithAuthor(val article: Article, val author: Author)
+
+    interface NewsRepository {
+        suspend fun fetchLatestNews(): List<Article>
+    }
+
+    interface AuthorsRepository {
+        suspend fun getAuthor(authorId: String): Author
+    }
+
+    // [START android_architecture_domain_layer_combine_repositories]
+    /**
+     * This use case fetches the latest news and the associated author.
+     */
+    class GetLatestNewsWithAuthorsUseCase(
+        private val newsRepository: NewsRepository,
+        private val authorsRepository: AuthorsRepository,
+        private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+    ) {
+        suspend operator fun invoke(): List<ArticleWithAuthor> =
+            withContext(defaultDispatcher) {
+                val news = newsRepository.fetchLatestNews()
+                val result: MutableList<ArticleWithAuthor> = mutableListOf()
+                // This is not parallelized, the use case is linearly slow.
+                for (article in news) {
+                    // The repository exposes suspend functions
+                    val author = authorsRepository.getAuthor(article.authorId)
+                    result.add(ArticleWithAuthor(article, author))
+                }
+                result
+            }
+    }
+    // [END android_architecture_domain_layer_combine_repositories]
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/Events.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/Events.kt
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.dropUnlessResumed
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+
+private object EventsSnippet1 {
+    class LatestNewsViewModel : ViewModel() {
+        fun refreshNews() {}
+    }
+
+    // [START android_architecture_ui_layer_events_user_events]
+    @Composable
+    fun LatestNewsScreen(viewModel: LatestNewsViewModel = viewModel()) {
+
+        // State of whether more details should be shown
+        var expanded by remember { mutableStateOf(false) }
+
+        Column {
+            Text("Some text")
+            if (expanded) {
+                Text("More details")
+            }
+
+            Button(
+                // The expand details event is processed by the UI that
+                // modifies this composable's internal state.
+                onClick = { expanded = !expanded }
+            ) {
+                val expandText = if (expanded) "Collapse" else "Expand"
+                Text("$expandText details")
+            }
+
+            // The refresh event is processed by the ViewModel that is in charge
+            // of the UI's business logic.
+            Button(onClick = { viewModel.refreshNews() }) {
+                Text("Refresh data")
+            }
+        }
+    }
+    // [END android_architecture_ui_layer_events_user_events]
+}
+
+private object EventsSnippet2 {
+    // [START android_architecture_ui_layer_events_lazy_list]
+    data class MyItem(val id: Int)
+
+    @Composable
+    fun MyList(
+        items: List<String>,
+        onItemClick: (MyItem) -> Unit
+    ) {
+        Card {
+            LazyColumn {
+                itemsIndexed(items) { index, string ->
+                    ListItem(
+                        modifier = Modifier.clickable {
+                            onItemClick(MyItem(index))
+                        },
+                        headlineContent = {
+                            Text(text = string)
+                        }
+                    )
+                }
+            }
+        }
+    }
+    // [END android_architecture_ui_layer_events_lazy_list]
+}
+
+private object EventsSnippet3 {
+    // [START android_architecture_ui_layer_events_login_ui_state]
+    data class LoginUiState(
+        val isLoginInProgress: Boolean = false,
+        val errorMessage: String? = null,
+        val isUserLoggedIn: Boolean = false
+    )
+    // [END android_architecture_ui_layer_events_login_ui_state]
+}
+
+private object EventsSnippet4 {
+    data class LoginUiState(
+        val isLoginInProgress: Boolean = false,
+        val errorMessage: String? = null,
+        val isUserLoggedIn: Boolean = false
+    )
+
+    // [START android_architecture_ui_layer_events_login_flow]
+    class LoginViewModel : ViewModel() {
+
+        var uiState by mutableStateOf(LoginUiState())
+
+        fun tryLogin(username: String, password: String) {
+            viewModelScope.launch {
+                // Emit a new state indicating that login is in progress
+                uiState = uiState.copy(isLoginInProgress = true)
+
+                uiState = if (login(username, password)) {
+                    // Emit a new state indicating that login was successful
+                    uiState.copy(isLoginInProgress = false, isUserLoggedIn = true)
+                } else {
+                    // Emit a new state with the error message
+                    LoginUiState(isLoginInProgress = false, errorMessage = "Login failed")
+                }
+            }
+        }
+
+        private suspend fun login(username: String, password: String): Boolean {
+            delay(1000)
+            return (username == "Hello" && password == "World!")
+        }
+    }
+
+    @Composable
+    fun LoginScreen(viewModel: LoginViewModel, onSuccessfulLogin: () -> Unit) {
+
+        val uiState = viewModel.uiState
+
+        LaunchedEffect(uiState) {
+            if (uiState.isUserLoggedIn) {
+                onSuccessfulLogin()
+            }
+        }
+
+        if (uiState.isLoginInProgress) {
+            CircularProgressIndicator()
+        } else {
+            LoginForm(
+                onLoginAttempt = { username, password ->
+                    viewModel.tryLogin(username, password)
+                },
+                errorMessage = uiState.errorMessage
+            )
+        }
+    }
+    // [END android_architecture_ui_layer_events_login_flow]
+
+    @Composable
+    private fun LoginForm(
+        onLoginAttempt: (String, String) -> Unit,
+        errorMessage: String?
+    ) {}
+}
+
+private object EventsSnippet5 {
+    class News
+
+    // [START android_architecture_ui_layer_events_latest_news_ui_state]
+    // Models the UI state for the Latest news screen.
+    data class LatestNewsUiState(
+        val news: List<News> = emptyList(),
+        val isLoading: Boolean = false,
+        val userMessage: String? = null
+    )
+    // [END android_architecture_ui_layer_events_latest_news_ui_state]
+}
+
+private object EventsSnippet6 {
+    data class LatestNewsUiState(
+        val news: List<String> = emptyList(),
+        val isLoading: Boolean = false,
+        val userMessage: String? = null
+    )
+
+    private fun internetConnection(): Boolean = true
+
+    // [START android_architecture_ui_layer_events_latest_news_viewmodel]
+    class LatestNewsViewModel(/* ... */) : ViewModel() {
+
+        var uiState by mutableStateOf(LatestNewsUiState())
+            private set
+
+        fun refreshNews() {
+            viewModelScope.launch {
+                // If there isn't internet connection, show a new message on the screen.
+                if (!internetConnection()) {
+                    uiState = uiState.copy(userMessage = "No Internet connection")
+                    return@launch
+                }
+
+                // Do something else.
+            }
+        }
+
+        fun userMessageShown() {
+            uiState = uiState.copy(userMessage = null)
+        }
+    }
+    // [END android_architecture_ui_layer_events_latest_news_viewmodel]
+}
+
+private object EventsSnippet7 {
+    data class LatestNewsUiState(val userMessage: String? = null)
+    class LatestNewsViewModel : ViewModel() {
+        val uiState: LatestNewsUiState = LatestNewsUiState()
+        fun userMessageShown() {}
+    }
+
+    // [START android_architecture_ui_layer_events_latest_news_snackbar]
+    @Composable
+    fun LatestNewsScreen(
+        snackbarHostState: SnackbarHostState,
+        viewModel: LatestNewsViewModel = viewModel(),
+    ) {
+        // Rest of the UI content.
+
+        // If there are user messages to show on the screen,
+        // show it and notify the ViewModel.
+        viewModel.uiState.userMessage?.let { userMessage ->
+            LaunchedEffect(userMessage) {
+                snackbarHostState.showSnackbar(userMessage)
+                // Once the message is displayed and dismissed, notify the ViewModel.
+                viewModel.userMessageShown()
+            }
+        }
+    }
+    // [END android_architecture_ui_layer_events_latest_news_snackbar]
+}
+
+private object EventsSnippet8 {
+    class LoginViewModel : ViewModel()
+
+    // [START android_architecture_ui_layer_events_login_help]
+    @Composable
+    fun LoginScreen(
+        onHelp: () -> Unit, // Caller navigates to the help screen
+        viewModel: LoginViewModel = viewModel()
+    ) {
+        // Rest of the UI
+        Button(
+            onClick = dropUnlessResumed { onHelp() }
+        ) {
+            Text("Get help")
+        }
+    }
+    // [END android_architecture_ui_layer_events_login_help]
+}
+
+private object EventsSnippet9 {
+    data class LoginUiState(val isUserLoggedIn: Boolean = false)
+    class LoginViewModel : ViewModel() {
+        val uiState = LoginUiState()
+        fun tryLogin() {}
+    }
+
+    // [START android_architecture_ui_layer_events_navigation_login]
+    @Composable
+    fun LoginScreen(
+        onUserLogIn: () -> Unit, // Caller navigates to the right screen
+        viewModel: LoginViewModel = viewModel()
+    ) {
+        Button(
+            onClick = {
+                // ViewModel validation is triggered
+                viewModel.tryLogin()
+            }
+        ) {
+            Text("Log in")
+        }
+        // Rest of the UI
+
+        val lifecycle = LocalLifecycleOwner.current.lifecycle
+        val currentOnUserLogIn by rememberUpdatedState(onUserLogIn)
+        LaunchedEffect(viewModel, lifecycle) {
+            // Whenever the uiState changes, check if the user is logged in and
+            // call the `onUserLogin` event when `lifecycle` is at least STARTED
+            snapshotFlow { viewModel.uiState }
+                .filter { it.isUserLoggedIn }
+                .flowWithLifecycle(lifecycle)
+                .collect {
+                    currentOnUserLogIn()
+                }
+        }
+    }
+    // [END android_architecture_ui_layer_events_navigation_login]
+}
+
+private object EventsSnippet10 {
+    data class DobValidationUiState(val isDobValid: Boolean = false)
+
+    // [START android_architecture_ui_layer_events_dob_validation]
+    class DobValidationViewModel(/* ... */) : ViewModel() {
+        var uiState by mutableStateOf(DobValidationUiState())
+            private set
+        /* [START_EXCLUDE silent] */
+        fun validateInput() {}
+        /* [END_EXCLUDE] */
+    }
+
+    @Composable
+    fun DobValidationScreen(
+        onNavigateToNextScreen: () -> Unit, // Caller navigates to the right screen
+        viewModel: DobValidationViewModel = viewModel()
+    ) {
+        // TextField that updates the ViewModel when a date of birth is selected
+
+        var validationInProgress by rememberSaveable { mutableStateOf(false) }
+
+        Button(
+            onClick = {
+                viewModel.validateInput()
+                validationInProgress = true
+            }
+        ) {
+            Text("Continue")
+        }
+        // Rest of the UI
+
+        /*
+         * The following code implements the requirement of advancing automatically
+         * to the next screen when a valid date of birth has been introduced
+         * and the user wanted to continue with the registration process.
+         */
+
+        if (validationInProgress) {
+            val lifecycle = LocalLifecycleOwner.current.lifecycle
+            val currentNavigateToNextScreen by rememberUpdatedState(onNavigateToNextScreen)
+            LaunchedEffect(viewModel, lifecycle) {
+                // If the date of birth is valid and the validation is in progress,
+                // navigate to the next screen when `lifecycle` is at least STARTED,
+                // which is the default Lifecycle.State for the `flowWithLifecycle` operator.
+                snapshotFlow { viewModel.uiState }
+                    .filter { it.isDobValid }
+                    .flowWithLifecycle(lifecycle)
+                    .collect {
+                        validationInProgress = false
+                        currentNavigateToNextScreen()
+                    }
+            }
+        }
+    }
+    // [END android_architecture_ui_layer_events_dob_validation]
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/OfflineFirst.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/OfflineFirst.kt
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import android.content.Context
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingState
+import androidx.paging.RemoteMediator
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.startup.Initializer
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ListenableWorker
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlin.reflect.KClass
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+private object OfflineFirstSnippet1 {
+    // [START android_architecture_offline_first_models_network_local]
+    /**
+     * Network representation of [Author]
+     */
+    @Serializable
+    data class NetworkAuthor(
+        val id: String,
+        val name: String,
+        val imageUrl: String,
+        val twitter: String,
+        val mediumPage: String,
+        val bio: String,
+    )
+
+    /**
+     * Defines an author for either an [EpisodeEntity] or [NewsResourceEntity].
+     * It has a many-to-many relationship with both entities
+     */
+    @Entity(tableName = "authors")
+    data class AuthorEntity(
+        @PrimaryKey
+        val id: String,
+        val name: String,
+        @ColumnInfo(name = "image_url")
+        val imageUrl: String,
+        @ColumnInfo(defaultValue = "")
+        val twitter: String,
+        @ColumnInfo(name = "medium_page", defaultValue = "")
+        val mediumPage: String,
+        @ColumnInfo(defaultValue = "")
+        val bio: String,
+    )
+    // [END android_architecture_offline_first_models_network_local]
+}
+
+private object OfflineFirstSnippet2 {
+    // [START android_architecture_offline_first_model_external]
+    /**
+     * External data layer representation of a "Now in Android" Author
+     */
+    data class Author(
+        val id: String,
+        val name: String,
+        val imageUrl: String,
+        val twitter: String,
+        val mediumPage: String,
+        val bio: String,
+    )
+    // [END android_architecture_offline_first_model_external]
+}
+
+private object OfflineFirstSnippet3 {
+    data class NetworkAuthor(
+        val id: String,
+        val name: String,
+        val imageUrl: String,
+        val twitter: String,
+        val mediumPage: String,
+        val bio: String,
+    )
+
+    data class AuthorEntity(
+        val id: String,
+        val name: String,
+        val imageUrl: String,
+        val twitter: String,
+        val mediumPage: String,
+        val bio: String,
+    )
+
+    data class Author(
+        val id: String,
+        val name: String,
+        val imageUrl: String,
+        val twitter: String,
+        val mediumPage: String,
+        val bio: String,
+    )
+
+    // [START android_architecture_offline_first_mappers]
+    /**
+     * Converts the network model to the local model for persisting
+     * by the local data source
+     */
+    fun NetworkAuthor.asEntity() = AuthorEntity(
+        id = id,
+        name = name,
+        imageUrl = imageUrl,
+        twitter = twitter,
+        mediumPage = mediumPage,
+        bio = bio,
+    )
+
+    /**
+     * Converts the local model to the external model for use
+     * by layers external to the data layer
+     */
+    fun AuthorEntity.asExternalModel() = Author(
+        id = id,
+        name = name,
+        imageUrl = imageUrl,
+        twitter = twitter,
+        mediumPage = mediumPage,
+        bio = bio,
+    )
+    // [END android_architecture_offline_first_mappers]
+}
+
+private object OfflineFirstSnippet4 {
+    data class Topic(val id: String, val name: String)
+    interface OfflineFirstTopicsRepository {
+        fun getTopicsStream(): Flow<List<Topic>>
+    }
+
+    // [START android_architecture_offline_first_topics_viewmodel]
+    class TopicsViewModel(
+        offlineFirstTopicsRepository: OfflineFirstTopicsRepository
+    ) : ViewModel() {
+
+        val topics: StateFlow<List<Topic>> = offlineFirstTopicsRepository.getTopicsStream()
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = emptyList()
+            )
+    }
+    // [END android_architecture_offline_first_topics_viewmodel]
+}
+
+private object OfflineFirstSnippet5 {
+    data class Author(val id: String = "", val name: String = "") {
+        companion object {
+            fun empty() = Author()
+        }
+    }
+
+    interface AuthorsRepository {
+        fun getAuthorStream(id: String): Flow<Author>
+    }
+
+    // [START android_architecture_offline_first_author_viewmodel_catch]
+    class AuthorViewModel(
+        authorsRepository: AuthorsRepository,
+        /* [START_EXCLUDE silent] */
+        authorId: String = ""
+        /* [END_EXCLUDE] */
+    ) : ViewModel() {
+        private val authorId: String = /* [START_EXCLUDE] */ authorId /* [END_EXCLUDE] */
+
+        // Observe author information
+        private val authorStream: Flow<Author> =
+            authorsRepository.getAuthorStream(
+                id = authorId
+            )
+                .catch { emit(Author.empty()) }
+    }
+    // [END android_architecture_offline_first_author_viewmodel_catch]
+}
+
+private object OfflineFirstSnippet6 {
+    data class Author(val id: String = "", val name: String = "")
+
+    interface AuthorsRepository {
+        fun getAuthorStream(id: String): Flow<Author>
+    }
+
+    // [START android_architecture_offline_first_author_lce]
+    // Define the LCE UI state
+    sealed interface AuthorUiState {
+        data object Loading : AuthorUiState
+        data class Success(val author: Author) : AuthorUiState
+        data object Error : AuthorUiState
+    }
+
+    class AuthorViewModel(
+        authorsRepository: AuthorsRepository,
+        /* [START_EXCLUDE silent] */
+        authorId: String = ""
+        /* [END_EXCLUDE] */
+    ) : ViewModel() {
+        private val authorId: String = /* [START_EXCLUDE] */ authorId /* [END_EXCLUDE] */
+
+        // Observe author information and map to LCE state
+        val authorUiState: StateFlow<AuthorUiState> =
+            authorsRepository.getAuthorStream(id = authorId)
+                .map<Author, AuthorUiState> { author ->
+                    AuthorUiState.Success(author)
+                }
+                .catch { emit(AuthorUiState.Error) }
+                .stateIn(
+                    scope = viewModelScope,
+                    started = SharingStarted.WhileSubscribed(5_000),
+                    initialValue = AuthorUiState.Loading
+                )
+    }
+    // [END android_architecture_offline_first_author_lce]
+}
+
+private object OfflineFirstSnippet7 {
+    // [START android_architecture_offline_first_user_data_repository_write]
+    interface UserDataRepository {
+        /**
+         * Updates the bookmarked status for a news resource
+         */
+        suspend fun updateNewsResourceBookmark(newsResourceId: String, bookmarked: Boolean)
+    }
+    // [END android_architecture_offline_first_user_data_repository_write]
+}
+
+private object OfflineFirstSnippet8 {
+    const val NETWORK_PAGE_SIZE = 20
+    data class FeedItem(val id: String)
+
+    typealias PagingSource<Value> = androidx.paging.PagingSource<Int, Value>
+
+    @OptIn(ExperimentalPagingApi::class)
+    class FeedRemoteMediator(/* ... */) : RemoteMediator<Int, FeedItem>() {
+        override suspend fun load(
+            loadType: androidx.paging.LoadType,
+            state: PagingState<Int, FeedItem>
+        ): MediatorResult = MediatorResult.Success(endOfPaginationReached = true)
+    }
+
+    // [START android_architecture_offline_first_paging_pull_sync]
+    class FeedRepository(/* ... */) {
+
+        fun feedPagingSource(): PagingSource<FeedItem> {
+            /* [START_EXCLUDE silent] */
+            return object : androidx.paging.PagingSource<Int, FeedItem>() {
+                override fun getRefreshKey(state: PagingState<Int, FeedItem>): Int? = null
+                override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FeedItem> =
+                    LoadResult.Page(emptyList(), null, null)
+            }
+            /* [END_EXCLUDE] */
+        }
+    }
+
+    @OptIn(ExperimentalPagingApi::class)
+    class FeedViewModel(
+        private val repository: FeedRepository
+    ) : ViewModel() {
+        /* [START_EXCLUDE silent] */
+        private val feedRepository = repository
+        /* [END_EXCLUDE] */
+        private val pager = Pager(
+            config = PagingConfig(
+                pageSize = NETWORK_PAGE_SIZE,
+                enablePlaceholders = false
+            ),
+            remoteMediator = FeedRemoteMediator(/* ... */),
+            pagingSourceFactory = feedRepository::feedPagingSource
+        )
+
+        val feedPagingData = pager.flow
+    }
+    // [END android_architecture_offline_first_paging_pull_sync]
+}
+
+private object OfflineFirstSnippet9 {
+    class UserData
+    class NetworkDataSource {
+        fun fetchUserData(): UserData = UserData()
+    }
+    class LocalDataSource {
+        fun saveUserData(data: UserData) {}
+    }
+
+    // [START android_architecture_offline_first_push_sync]
+    class UserDataRepository(
+        /* [START_EXCLUDE silent] */
+        private val networkDataSource: NetworkDataSource = NetworkDataSource(),
+        private val localDataSource: LocalDataSource = LocalDataSource()
+        /* [END_EXCLUDE] */
+    ) {
+
+        suspend fun synchronize() {
+            val userData = networkDataSource.fetchUserData()
+            localDataSource.saveUserData(userData)
+        }
+    }
+    // [END android_architecture_offline_first_push_sync]
+}
+
+private object OfflineFirstSnippet10 {
+    object Sync
+    const val SyncWorkName = "SyncWork"
+
+    // [START android_architecture_offline_first_sync_initializer]
+    class SyncInitializer : Initializer<Sync> {
+        override fun create(context: Context): Sync {
+            WorkManager.getInstance(context).apply {
+                // Queue sync on app startup and ensure only one
+                // sync worker runs at any time
+                enqueueUniqueWork(
+                    SyncWorkName,
+                    ExistingWorkPolicy.KEEP,
+                    SyncWorker.startUpSyncWork()
+                )
+            }
+            return Sync
+        }
+        /* [START_EXCLUDE silent] */
+        override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+        /* [END_EXCLUDE] */
+    }
+    // [END android_architecture_offline_first_sync_initializer]
+}
+
+private object OfflineFirstSnippet11 {
+    // [START android_architecture_offline_first_sync_work_request]
+    /**
+     Create a WorkRequest to call the SyncWorker using a DelegatingWorker.
+     This allows for dependency injection into the SyncWorker in a different
+     module than the app module without having to create a custom WorkManager
+     configuration.
+     */
+    fun startUpSyncWork() = OneTimeWorkRequestBuilder<DelegatingWorker>()
+        // Run sync as expedited work if the app is able to.
+        // If not, it runs as regular work.
+        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+        .setConstraints(SyncConstraints)
+        // Delegate to the SyncWorker.
+        .setInputData(SyncWorker::class.delegatedData())
+        .build()
+
+    val SyncConstraints
+        get() = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+    // [END android_architecture_offline_first_sync_work_request]
+}
+
+private object OfflineFirstSnippet12 {
+    class TopicRepository {
+        suspend fun sync(): Boolean = true
+    }
+    class AuthorsRepository {
+        suspend fun sync(): Boolean = true
+    }
+    class NewsRepository {
+        suspend fun sync(): Boolean = true
+    }
+
+    // [START android_architecture_offline_first_sync_worker]
+    class SyncWorker(
+        /* [START_EXCLUDE silent] */
+        appContext: Context,
+        workerParams: WorkerParameters,
+        private val topicRepository: TopicRepository = TopicRepository(),
+        private val authorsRepository: AuthorsRepository = AuthorsRepository(),
+        private val newsRepository: NewsRepository = NewsRepository(),
+        private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+        /* [END_EXCLUDE] */
+    ) : CoroutineWorker(appContext, workerParams), Synchronizer {
+
+        override suspend fun doWork(): Result = withContext(ioDispatcher) {
+            // First sync the repositories in parallel
+            val syncedSuccessfully = awaitAll(
+                async { topicRepository.sync() },
+                async { authorsRepository.sync() },
+                async { newsRepository.sync() },
+            ).all { it }
+
+            if (syncedSuccessfully) Result.success()
+            else Result.retry()
+        }
+    }
+    // [END android_architecture_offline_first_sync_worker]
+}
+
+private class DelegatingWorker(context: Context, params: WorkerParameters) : ListenableWorker(context, params) {
+    override fun startWork() = throw UnsupportedOperationException()
+}
+
+private object SyncWorker {
+    fun startUpSyncWork(): OneTimeWorkRequest = OneTimeWorkRequestBuilder<DelegatingWorker>().build()
+}
+
+private fun KClass<*>.delegatedData(): Data = workDataOf()
+
+private interface Synchronizer

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/StateHolders.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/StateHolders.kt
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ScaffoldState
+import androidx.compose.material.rememberScaffoldState
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavDestination
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+private object StateHoldersSnippet1 {
+    // [START android_architecture_stateholders_ui_state_simple_counter]
+    @Composable
+    fun Counter() {
+        // The UI state is managed by the UI itself
+        var count by remember { mutableStateOf(0) }
+        Row {
+            Button(onClick = { ++count }) {
+                Text(text = "Increment")
+            }
+            Button(onClick = { --count }) {
+                Text(text = "Decrement")
+            }
+        }
+    }
+    // [END android_architecture_stateholders_ui_state_simple_counter]
+}
+
+private object StateHoldersSnippet2 {
+    data class Contact(val name: String)
+    @Composable private fun ScrollToTopButton() {}
+
+    // [START android_architecture_stateholders_ui_logic_contacts_list]
+    @Composable
+    fun ContactsList(contacts: List<Contact>) {
+        val listState = rememberLazyListState()
+        val isAtTopOfList by remember {
+            derivedStateOf {
+                listState.firstVisibleItemIndex < 3
+            }
+        }
+
+        // Create the LazyColumn with the lazyListState
+        // ...
+        /* [START_EXCLUDE silent] */
+        LazyColumn(state = listState) {
+            items(contacts) { Text(it.name) }
+        }
+        /* [END_EXCLUDE] */
+
+        // Show or hide the button (UI logic) based on the list scroll position
+        AnimatedVisibility(visible = !isAtTopOfList) {
+            ScrollToTopButton()
+        }
+    }
+    // [END android_architecture_stateholders_ui_logic_contacts_list]
+}
+
+private object StateHoldersSnippet3 {
+    data class UserProfileUiState(val profilePicture: String = "")
+    class UserProfileViewModel : ViewModel() {
+        val uiState = MutableStateFlow(UserProfileUiState())
+    }
+    @Composable private fun UserAvatar(picture: String) {}
+
+    // [START android_architecture_stateholders_business_logic_user_profile]
+    @Composable
+    fun UserProfileScreen(viewModel: UserProfileViewModel = hiltViewModel()) {
+        // Read screen UI state from the business logic state holder
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        // Call on the UserAvatar Composable to display the photo
+        UserAvatar(picture = uiState.profilePicture)
+    }
+    // [END android_architecture_stateholders_business_logic_user_profile]
+}
+
+private object StateHoldersSnippet4 {
+    data class Contact(val name: String)
+    data class ContactsUiState(
+        val contacts: List<Contact> = emptyList(),
+        val deepLinkedContact: Contact? = null
+    )
+    class ContactsViewModel : ViewModel() {
+        val uiState = MutableStateFlow(ContactsUiState())
+    }
+
+    // [START android_architecture_stateholders_business_and_ui_logic_contacts]
+    @Composable
+    fun ContactsList(viewModel: ContactsViewModel = hiltViewModel()) {
+        // Read screen UI state from the business logic state holder
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+        val contacts = uiState.contacts
+        val deepLinkedContact = uiState.deepLinkedContact
+
+        val listState = rememberLazyListState()
+
+        // Create the LazyColumn with the lazyListState
+        // ...
+        /* [START_EXCLUDE silent] */
+        LazyColumn(state = listState) {
+            items(contacts) { Text(it.name) }
+        }
+        /* [END_EXCLUDE] */
+
+        // Perform UI logic that depends on information from business logic
+        if (deepLinkedContact != null && contacts.isNotEmpty()) {
+            LaunchedEffect(listState, deepLinkedContact, contacts) {
+                val deepLinkedContactIndex = contacts.indexOf(deepLinkedContact)
+                if (deepLinkedContactIndex >= 0) {
+                    // Scroll to deep linked item
+                    listState.animateScrollToItem(deepLinkedContactIndex)
+                }
+            }
+        }
+    }
+    // [END android_architecture_stateholders_business_and_ui_logic_contacts]
+}
+
+object StateHoldersSnippet5 {
+    interface AuthorsRepository
+    interface NewsRepository
+    class AuthorScreenUiState
+
+    // [START android_architecture_stateholders_hilt_author_viewmodel]
+    @HiltViewModel
+    class AuthorViewModel @Inject constructor(
+        savedStateHandle: SavedStateHandle,
+        private val authorsRepository: AuthorsRepository,
+        newsRepository: NewsRepository
+    ) : ViewModel() {
+
+        val uiState: StateFlow<AuthorScreenUiState> = /* [START_EXCLUDE] */ MutableStateFlow(AuthorScreenUiState()) /* [END_EXCLUDE] */
+
+        // Business logic
+        fun followAuthor(followed: Boolean) {
+            /* [START_EXCLUDE silent] */
+            /* [END_EXCLUDE] */
+        }
+    }
+    // [END android_architecture_stateholders_hilt_author_viewmodel]
+}
+
+private object StateHoldersSnippet6 {
+    interface NiaNavigationDestination
+
+    // [START android_architecture_stateholders_plain_state_holder_nia_app_state]
+    @Stable
+    class NiaAppState(
+        val navController: NavHostController,
+        val windowSizeClass: WindowSizeClass
+    ) {
+
+        // UI logic
+        val shouldShowBottomBar: Boolean
+            get() = windowSizeClass.widthSizeClass == WindowWidthSizeClass.Compact ||
+                windowSizeClass.heightSizeClass == WindowHeightSizeClass.Compact
+
+        // UI logic
+        val shouldShowNavRail: Boolean
+            get() = !shouldShowBottomBar
+
+        // UI State
+        val currentDestination: NavDestination?
+            @Composable get() = navController
+                .currentBackStackEntryAsState().value?.destination
+
+        // UI logic
+        fun navigate(destination: NiaNavigationDestination, route: String? = null) { /* ... */ }
+
+        /* ... */
+    }
+    // [END android_architecture_stateholders_plain_state_holder_nia_app_state]
+}
+
+private object StateHoldersSnippet7 {
+    enum class DrawerValue { Closed, Open }
+
+    // [START android_architecture_stateholders_compoundable_state_holders]
+    @Stable
+    class DrawerState(/* ... */) {
+        /* [START_EXCLUDE silent] */
+        class SwipeableState(vararg args: Any?)
+        /* [END_EXCLUDE] */
+        internal val swipeableState = SwipeableState(/* ... */)
+        // ...
+    }
+
+    @Stable
+    class MyAppState(
+        private val drawerState: DrawerState,
+        private val navController: NavHostController
+    ) { /* ... */ }
+
+    @Composable
+    fun rememberMyAppState(
+        drawerState: DrawerState = rememberDrawerState(DrawerValue.Closed),
+        navController: NavHostController = rememberNavController()
+    ): MyAppState = remember(drawerState, navController) {
+        MyAppState(drawerState, navController)
+    }
+    // [END android_architecture_stateholders_compoundable_state_holders]
+
+    @Composable
+    private fun rememberDrawerState(initialValue: DrawerValue): DrawerState =
+        remember { DrawerState() }
+}
+
+private object StateHoldersSnippet8 {
+    class SomeState
+    data class MyScreenUiState(val value: String = "") {
+        fun toSomeState(): SomeState = SomeState()
+    }
+
+    private fun <T, R> StateFlow<T>.map(transform: (T) -> R): StateFlow<R> =
+        MutableStateFlow(transform(value))
+
+    // [START android_architecture_stateholders_dependencies_pass_params]
+    class MyScreenViewModel(/* ... */) /* [START_EXCLUDE silent] */ : ViewModel() /* [END_EXCLUDE] */ {
+        val uiState: StateFlow<MyScreenUiState> = /* ... */ /* [START_EXCLUDE silent] */ MutableStateFlow(MyScreenUiState()) /* [END_EXCLUDE] */
+        fun doSomething() { /* ... */ }
+        fun doAnotherThing() { /* ... */ }
+        // ...
+    }
+
+    @Stable
+    class MyScreenState(
+        // DO NOT pass a ViewModel instance to a plain state holder class
+        // private val viewModel: MyScreenViewModel,
+
+        // Instead, pass only what it needs as a dependency
+        private val someState: StateFlow<SomeState>,
+        private val doSomething: () -> Unit,
+
+        // Other UI-scoped types
+        private val scaffoldState: ScaffoldState
+    ) {
+        /* ... */
+    }
+
+    @Composable
+    fun rememberMyScreenState(
+        someState: StateFlow<SomeState>,
+        doSomething: () -> Unit,
+        scaffoldState: ScaffoldState = rememberScaffoldState()
+    ): MyScreenState = remember(someState, doSomething, scaffoldState) {
+        MyScreenState(someState, doSomething, scaffoldState)
+    }
+
+    @Composable
+    fun MyScreen(
+        modifier: Modifier = Modifier,
+        viewModel: MyScreenViewModel = viewModel(),
+        state: MyScreenState = rememberMyScreenState(
+            someState = viewModel.uiState.map { it.toSomeState() },
+            doSomething = viewModel::doSomething
+        ),
+        // ...
+    ) {
+        /* ... */
+    }
+    // [END android_architecture_stateholders_dependencies_pass_params]
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/architecture/StateProduction.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/architecture/StateProduction.kt
@@ -1,0 +1,441 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.architecture
+
+import androidx.annotation.MainThread
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.random.Random
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private object StateProductionSnippet1 {
+    // [START android_architecture_state_production_dice_roll_compose_state]
+    @Stable
+    interface DiceUiState {
+        val firstDieValue: Int?
+        val secondDieValue: Int?
+        val numberOfRolls: Int?
+    }
+
+    private class MutableDiceUiState : DiceUiState {
+        override var firstDieValue: Int? by mutableStateOf(null)
+        override var secondDieValue: Int? by mutableStateOf(null)
+        override var numberOfRolls: Int by mutableStateOf(0)
+    }
+
+    class DiceRollViewModel : ViewModel() {
+
+        private val _uiState = MutableDiceUiState()
+        val uiState: DiceUiState = _uiState
+
+        // Called from the UI
+        fun rollDice() {
+            _uiState.firstDieValue = Random.nextInt(from = 1, until = 7)
+            _uiState.secondDieValue = Random.nextInt(from = 1, until = 7)
+            _uiState.numberOfRolls = _uiState.numberOfRolls + 1
+        }
+    }
+    // [END android_architecture_state_production_dice_roll_compose_state]
+}
+
+private object StateProductionSnippet2 {
+    // [START android_architecture_state_production_dice_roll_state_flow]
+    data class DiceUiState(
+        val firstDieValue: Int? = null,
+        val secondDieValue: Int? = null,
+        val numberOfRolls: Int = 0,
+    )
+
+    class DiceRollViewModel : ViewModel() {
+
+        private val _uiState = MutableStateFlow(DiceUiState())
+        val uiState: StateFlow<DiceUiState> = _uiState.asStateFlow()
+
+        // Called from the UI
+        fun rollDice() {
+            _uiState.update { currentState ->
+                currentState.copy(
+                    firstDieValue = Random.nextInt(from = 1, until = 7),
+                    secondDieValue = Random.nextInt(from = 1, until = 7),
+                    numberOfRolls = currentState.numberOfRolls + 1,
+                )
+            }
+        }
+    }
+    // [END android_architecture_state_production_dice_roll_state_flow]
+}
+
+private object StateProductionSnippet3 {
+    data class Task(val title: String, val description: String)
+    interface TasksRepository {
+        suspend fun saveTask(task: Task)
+    }
+    private fun getErrorMessage(e: Exception): String = e.message ?: ""
+
+    // [START android_architecture_state_production_add_edit_task_compose_state]
+    @Stable
+    interface AddEditTaskUiState {
+        val title: String
+        val description: String
+        val isTaskCompleted: Boolean
+        val isLoading: Boolean
+        val userMessage: String?
+        val isTaskSaved: Boolean
+    }
+
+    private class MutableAddEditTaskUiState : AddEditTaskUiState {
+        override var title: String by mutableStateOf("")
+        override var description: String by mutableStateOf("")
+        override var isTaskCompleted: Boolean by mutableStateOf(false)
+        override var isLoading: Boolean by mutableStateOf(false)
+        override var userMessage: String? by mutableStateOf<String?>(null)
+        override var isTaskSaved: Boolean by mutableStateOf(false)
+    }
+
+    class AddEditTaskViewModel(
+        /* [START_EXCLUDE silent] */
+        private val tasksRepository: TasksRepository = object : TasksRepository {
+            override suspend fun saveTask(task: Task) {}
+        }
+        /* [END_EXCLUDE] */
+    ) : ViewModel() {
+
+        private val _uiState = MutableAddEditTaskUiState()
+        val uiState: AddEditTaskUiState = _uiState
+
+        private fun createNewTask() {
+            viewModelScope.launch {
+                val newTask = Task(uiState.title, uiState.description)
+                try {
+                    tasksRepository.saveTask(newTask)
+                    // Write data into the UI state.
+                    _uiState.isTaskSaved = true
+                } catch (cancellationException: CancellationException) {
+                    throw cancellationException
+                } catch (exception: Exception) {
+                    _uiState.userMessage = getErrorMessage(exception)
+                }
+            }
+        }
+    }
+    // [END android_architecture_state_production_add_edit_task_compose_state]
+}
+
+private object StateProductionSnippet4 {
+    data class Task(val title: String, val description: String)
+    interface TasksRepository {
+        suspend fun saveTask(task: Task)
+    }
+    private fun getErrorMessage(e: Exception): String = e.message ?: ""
+
+    // [START android_architecture_state_production_add_edit_task_state_flow]
+    data class AddEditTaskUiState(
+        val title: String = "",
+        val description: String = "",
+        val isTaskCompleted: Boolean = false,
+        val isLoading: Boolean = false,
+        val userMessage: String? = null,
+        val isTaskSaved: Boolean = false
+    )
+
+    class AddEditTaskViewModel(
+        /* [START_EXCLUDE silent] */
+        private val tasksRepository: TasksRepository = object : TasksRepository {
+            override suspend fun saveTask(task: Task) {}
+        }
+        /* [END_EXCLUDE] */
+    ) : ViewModel() {
+
+        private val _uiState = MutableStateFlow(AddEditTaskUiState())
+        val uiState: StateFlow<AddEditTaskUiState> = _uiState.asStateFlow()
+
+        private fun createNewTask() {
+            viewModelScope.launch {
+                val newTask = Task(uiState.value.title, uiState.value.description)
+                try {
+                    tasksRepository.saveTask(newTask)
+                    // Write data into the UI state.
+                    _uiState.update {
+                        it.copy(isTaskSaved = true)
+                    }
+                } catch (cancellationException: CancellationException) {
+                    throw cancellationException
+                } catch (exception: Exception) {
+                    _uiState.update {
+                        it.copy(userMessage = getErrorMessage(exception))
+                    }
+                }
+            }
+        }
+    }
+    // [END android_architecture_state_production_add_edit_task_state_flow]
+}
+
+private object StateProductionSnippet5 {
+    @Stable
+    interface DiceUiState {
+        var firstDieValue: Int?
+        var secondDieValue: Int?
+        var numberOfRolls: Int
+    }
+
+    private class MutableDiceUiState : DiceUiState {
+        override var firstDieValue: Int? by mutableStateOf(null)
+        override var secondDieValue: Int? by mutableStateOf(null)
+        override var numberOfRolls: Int by mutableStateOf(0)
+    }
+
+    private object SlowRandom {
+        fun nextInt(from: Int, until: Int): Int = Random.nextInt(from, until)
+    }
+
+    // [START android_architecture_state_production_dice_roll_background_compose_state]
+    class DiceRollViewModel(
+        private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+    ) : ViewModel() {
+
+        private val _uiState = MutableDiceUiState()
+        val uiState: DiceUiState = _uiState
+
+        // Called from the UI
+        fun rollDice() {
+            viewModelScope.launch {
+                // Other Coroutines that may be called from the current context
+                /* ... */
+                withContext(defaultDispatcher) {
+                    Snapshot.withMutableSnapshot {
+                        _uiState.firstDieValue = SlowRandom.nextInt(from = 1, until = 7)
+                        _uiState.secondDieValue = SlowRandom.nextInt(from = 1, until = 7)
+                        _uiState.numberOfRolls = _uiState.numberOfRolls + 1
+                    }
+                }
+            }
+        }
+    }
+    // [END android_architecture_state_production_dice_roll_background_compose_state]
+}
+
+private object StateProductionSnippet6 {
+    data class DiceUiState(
+        val firstDieValue: Int? = null,
+        val secondDieValue: Int? = null,
+        val numberOfRolls: Int = 0,
+    )
+
+    private object SlowRandom {
+        fun nextInt(from: Int, until: Int): Int = Random.nextInt(from, until)
+    }
+
+    // [START android_architecture_state_production_dice_roll_background_state_flow]
+    class DiceRollViewModel(
+        private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+    ) : ViewModel() {
+
+        private val _uiState = MutableStateFlow(DiceUiState())
+        val uiState: StateFlow<DiceUiState> = _uiState.asStateFlow()
+
+        // Called from the UI
+        fun rollDice() {
+            viewModelScope.launch {
+                // Other Coroutines that may be called from the current context
+                /* ... */
+                withContext(defaultDispatcher) {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            firstDieValue = SlowRandom.nextInt(from = 1, until = 7),
+                            secondDieValue = SlowRandom.nextInt(from = 1, until = 7),
+                            numberOfRolls = currentState.numberOfRolls + 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+    // [END android_architecture_state_production_dice_roll_background_state_flow]
+}
+
+private object StateProductionSnippet7 {
+    data class Author(val id: String)
+    data class Topic(val id: String)
+    sealed interface InterestsUiState {
+        data object Loading : InterestsUiState
+        data class Interests(val authors: List<Author>, val topics: List<Topic>) : InterestsUiState
+    }
+
+    interface AuthorsRepository {
+        fun getAuthorsStream(): Flow<List<Author>>
+    }
+
+    interface TopicsRepository {
+        fun getTopicsStream(): Flow<List<Topic>>
+    }
+
+    // [START android_architecture_state_production_interests_viewmodel]
+    class InterestsViewModel(
+        authorsRepository: AuthorsRepository,
+        topicsRepository: TopicsRepository
+    ) : ViewModel() {
+
+        val uiState = combine(
+            authorsRepository.getAuthorsStream(),
+            topicsRepository.getTopicsStream(),
+        ) { availableAuthors, availableTopics ->
+            InterestsUiState.Interests(
+                authors = availableAuthors,
+                topics = availableTopics
+            )
+        }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = InterestsUiState.Loading
+            )
+    }
+    // [END android_architecture_state_production_interests_viewmodel]
+}
+
+object StateProductionSnippet8 {
+    data class Task(val name: String)
+    data class Async<T>(val data: Task? = null)
+    data class TaskDetailUiState(val task: Task? = null, val isTaskDeleted: Boolean = false)
+
+    interface TasksRepository {
+        fun getTaskStream(taskId: String): Flow<Async<Task>>
+        suspend fun deleteTask(taskId: String)
+    }
+
+    // [START android_architecture_state_production_task_detail_compose_state]
+    class TaskDetailViewModel @Inject constructor(
+        private val tasksRepository: TasksRepository,
+        savedStateHandle: SavedStateHandle
+    ) : ViewModel() {
+
+        /* [START_EXCLUDE silent] */
+        private val taskId: String = ""
+        /* [END_EXCLUDE] */
+        private var _isTaskDeleted by mutableStateOf(false)
+        private val _task = tasksRepository.getTaskStream(taskId)
+
+        val uiState: StateFlow<TaskDetailUiState> = combine(
+            snapshotFlow { _isTaskDeleted },
+            _task
+        ) { isTaskDeleted, taskAsync ->
+            TaskDetailUiState(
+                task = taskAsync.data,
+                isTaskDeleted = isTaskDeleted
+            )
+        }
+            // Convert the result to the appropriate observable API for the UI
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = TaskDetailUiState()
+            )
+
+        fun deleteTask() = viewModelScope.launch {
+            tasksRepository.deleteTask(taskId)
+            _isTaskDeleted = true
+        }
+    }
+    // [END android_architecture_state_production_task_detail_compose_state]
+}
+
+object StateProductionSnippet9 {
+    data class Task(val name: String)
+    data class Async<T>(val data: Task? = null)
+    data class TaskDetailUiState(val task: Task? = null, val isTaskDeleted: Boolean = false)
+
+    interface TasksRepository {
+        fun getTaskStream(taskId: String): Flow<Async<Task>>
+        suspend fun deleteTask(taskId: String)
+    }
+
+    // [START android_architecture_state_production_task_detail_state_flow]
+    class TaskDetailViewModel @Inject constructor(
+        private val tasksRepository: TasksRepository,
+        savedStateHandle: SavedStateHandle
+    ) : ViewModel() {
+
+        /* [START_EXCLUDE silent] */
+        private val taskId: String = ""
+        /* [END_EXCLUDE] */
+        private val _isTaskDeleted = MutableStateFlow(false)
+        private val _task = tasksRepository.getTaskStream(taskId)
+
+        val uiState: StateFlow<TaskDetailUiState> = combine(
+            _isTaskDeleted,
+            _task
+        ) { isTaskDeleted, taskAsync ->
+            TaskDetailUiState(
+                task = taskAsync.data,
+                isTaskDeleted = isTaskDeleted
+            )
+        }
+            // Convert the result to the appropriate observable API for the UI
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = TaskDetailUiState()
+            )
+
+        fun deleteTask() = viewModelScope.launch {
+            tasksRepository.deleteTask(taskId)
+            _isTaskDeleted.update { true }
+        }
+    }
+    // [END android_architecture_state_production_task_detail_state_flow]
+}
+
+private object StateProductionSnippet10 {
+    // [START android_architecture_state_production_viewmodel_initialize]
+    class MyViewModel : ViewModel() {
+
+        private var initializeCalled = false
+
+        // This function is idempotent provided it is only called from the UI thread.
+        @MainThread
+        fun initialize() {
+            if (initializeCalled) return
+            initializeCalled = true
+
+            viewModelScope.launch {
+                // seed the state production pipeline
+            }
+        }
+    }
+    // [END android_architecture_state_production_viewmodel_initialize]
+}

--- a/compose/snippets/src/main/java/com/example/compose/snippets/modularization/Patterns.kt
+++ b/compose/snippets/src/main/java/com/example/compose/snippets/modularization/Patterns.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.compose.snippets.modularization
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+private object ModularizationSnippet1 {
+    fun navigateToCheckout(navController: NavHostController, bookId: String) {
+        // [START android_modularization_patterns_navigation_primitive_id]
+        navController.navigate("checkout/$bookId")
+        // [END android_modularization_patterns_navigation_primitive_id]
+    }
+}
+
+private object ModularizationSnippet2 {
+    class CheckoutUiState
+    class BookRepository {
+        fun getBook(id: String): String = ""
+    }
+
+    // [START android_modularization_patterns_checkout_viewmodel]
+    class CheckoutViewModel(
+        savedStateHandle: SavedStateHandle,
+        /* [START_EXCLUDE] */
+        bookRepository: BookRepository = BookRepository()
+        /* [END_EXCLUDE] */
+    ) : ViewModel() {
+
+        val uiState: StateFlow<CheckoutUiState> =
+            savedStateHandle.getStateFlow<String>("bookId", "").map { bookId ->
+                // produce UI state calling bookRepository.getBook(bookId)
+                /* [START_EXCLUDE silent] */
+                CheckoutUiState()
+                /* [END_EXCLUDE] */
+            }
+                /* [START_EXCLUDE silent] */
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CheckoutUiState())
+        /* [END_EXCLUDE] */
+        /* ... */
+    }
+    // [END android_modularization_patterns_checkout_viewmodel]
+}


### PR DESCRIPTION
## Summary
- Brings this branch in sync with the upstream `android/snippets` branch of the same name by cherry-picking commit `7fe81e1` ("Migrate Architecture and Modularization snippets to GitHub").
- Adds the missing architecture snippet files: `DataLayer.kt`, `DomainLayer.kt`, `Events.kt`, `OfflineFirst.kt`, `StateHolders.kt`, `StateProduction.kt`.
- Adds `modularization/Patterns.kt`.
- Adds `androidx-room-common` and `androidx-startup-runtime` dependencies to `compose/snippets/build.gradle.kts` (required by the new snippets; both aliases already existed in `libs.versions.toml`).

## Test plan
- [x] `./gradlew :compose:snippets:compileDebugKotlin` passes
- [x] Verified file list now matches upstream `android/snippets:katherinekuan/architecture-modularization-snippets`
- [x] Verified build green in Studio without exceptions with testing on device (Samsung S25 Ultra)

## Files & Pages In Scope of this PR

## ArchitectureLayering.kt

DAC page: [https://developer.android.com/develop/ui/compose/layering](https://developer.android.com/develop/ui/compose/layering)

| Snippet | Lines |
|---|---|
| `android_compose_architecture_layering1` | 38-40 |
| `android_compose_architecture_layering2` | 45-49 |
| `android_compose_architecture_layering3` | 53-70 |
| `android_compose_architecture_layering4` | 72-95 |
| `android_compose_architecture_layering5` | 97-115 |

## ArchitectureSnippets.kt

DAC page: [https://developer.android.com/develop/ui/compose/architecture](https://developer.android.com/develop/ui/compose/architecture)

| Snippet | Lines |
|---|---|
| `android_compose_architecture_architecture1` | 46-53 |
| `android_compose_architecture_architecture2` | 59-69 |
| `android_compose_architecture_architecture3` | 75-99 |
| `android_compose_architecture_architecture4` | 110-119 |
| `android_compose_architecture_architecture5` | 123-137 |

---

## StateHolders.kt

DAC page: [https://developer.android.com/topic/architecture/ui-layer/stateholders](https://developer.android.com/topic/architecture/ui-layer/stateholders)

| Snippet | Lines |
|---|---|
| `android_architecture_stateholders_ui_state_simple_counter` | 55-69 |
| `android_architecture_stateholders_ui_logic_contacts_list` | 76-99 |
| `android_architecture_stateholders_business_logic_user_profile` | 109-118 |
| `android_architecture_stateholders_business_and_ui_logic_contacts` | 131-160 |
| `android_architecture_stateholders_hilt_author_viewmodel` | 168-184 |
| `android_architecture_stateholders_plain_state_holder_nia_app_state` | 190-216 |
| `android_architecture_stateholders_compoundable_state_holders` | 222-245 |
| `android_architecture_stateholders_dependencies_pass_params` | 261-305 |

## StateProduction.kt

DAC page: [https://developer.android.com/topic/architecture/ui-layer/state-production](https://developer.android.com/topic/architecture/ui-layer/state-production)

| Snippet | Lines |
|---|---|
| `android_architecture_state_production_dice_roll_compose_state` | 46-72 |
| `android_architecture_state_production_dice_roll_state_flow` | 76-99 |
| `android_architecture_state_production_add_edit_task_compose_state` | 109-155 |
| `android_architecture_state_production_add_edit_task_state_flow` | 165-205 |
| `android_architecture_state_production_dice_roll_background_compose_state` | 226-249 |
| `android_architecture_state_production_dice_roll_background_state_flow` | 263-288 |
| `android_architecture_state_production_interests_viewmodel` | 307-328 |
| `android_architecture_state_production_task_detail_compose_state` | 341-374 |
| `android_architecture_state_production_task_detail_state_flow` | 387-420 |
| `android_architecture_state_production_viewmodel_initialize` | 424-440 |

---

## Events.kt

DAC page: [https://developer.android.com/topic/architecture/ui-layer/events](https://developer.android.com/topic/architecture/ui-layer/events)

| Snippet | Lines |
|---|---|
| `android_architecture_ui_layer_events_user_events` | 54-83 |
| `android_architecture_ui_layer_events_lazy_list` | 87-110 |
| `android_architecture_ui_layer_events_login_ui_state` | 114-120 |
| `android_architecture_ui_layer_events_login_flow` | 130-178 |
| `android_architecture_ui_layer_events_latest_news_ui_state` | 190-197 |
| `android_architecture_ui_layer_events_latest_news_viewmodel` | 209-231 |
| `android_architecture_ui_layer_events_latest_news_snackbar` | 241-259 |
| `android_architecture_ui_layer_events_login_help` | 265-278 |
| `android_architecture_ui_layer_events_navigation_login` | 288-317 |
| `android_architecture_ui_layer_events_dob_validation` | 323-374 |

---

## DataLayer.kt

DAC page: [https://developer.android.com/topic/architecture/data-layer](https://developer.android.com/topic/architecture/data-layer)

| Snippet | Lines |
|---|---|
| `android_architecture_data_layer_repository_constructor` | 42-49 |
| `android_architecture_data_layer_expose_apis` | 57-69 |
| `android_architecture_data_layer_network_model` | 75-89 |
| `android_architecture_data_layer_business_model` | 93-102 |
| `android_architecture_data_layer_news_remote_data_source` | 108-129 |
| `android_architecture_data_layer_news_repository_fetch` | 138-146 |
| `android_architecture_data_layer_in_memory_cache` | 155-177 |
| `android_architecture_data_layer_external_scope_constructor` | 183-191 |
| `android_architecture_data_layer_external_scope_async` | 200-226 |
| `android_architecture_data_layer_refresh_latest_news_worker` | 234-248 |
| `android_architecture_data_layer_news_tasks_data_source` | 256-286 |

## DomainLayer.kt

DAC page: [https://developer.android.com/topic/architecture/domain-layer](https://developer.android.com/topic/architecture/domain-layer)

| Snippet | Lines |
|---|---|
| `android_architecture_domain_layer_dependencies` | 32-37 |
| `android_architecture_domain_layer_nested_dependencies` | 45-51 |
| `android_architecture_domain_layer_format_date_use_case` | 60-72 |
| `android_architecture_domain_layer_call_use_case_viewmodel` | 81-89 |
| `android_architecture_domain_layer_threading` | 93-102 |
| `android_architecture_domain_layer_combine_repositories` | 118-140 |

---

## OfflineFirst.kt

DAC page: [https://developer.android.com/topic/architecture/data-layer/offline-first](https://developer.android.com/topic/architecture/data-layer/offline-first)

| Snippet | Lines |
|---|---|
| `android_architecture_offline_first_models_network_local` | 59-91 |
| `android_architecture_offline_first_model_external` | 95-107 |
| `android_architecture_offline_first_mappers` | 138-164 |
| `android_architecture_offline_first_topics_viewmodel` | 173-185 |
| `android_architecture_offline_first_author_viewmodel_catch` | 199-215 |
| `android_architecture_offline_first_author_lce` | 225-254 |
| `android_architecture_offline_first_user_data_repository_write` | 258-264 |
| `android_architecture_offline_first_paging_pull_sync` | 282-314 |
| `android_architecture_offline_first_push_sync` | 326-339 |
| `android_architecture_offline_first_sync_initializer` | 347-363 |
| `android_architecture_offline_first_sync_work_request` | 369-388 |
| `android_architecture_offline_first_sync_worker` | 402-426 |

---

cc: @kkuan2011 